### PR TITLE
feat: [CW-22197][CW-23419][CW-23436] add ADA Abstain tx script

### DIFF
--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/AdaScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/AdaScript.java
@@ -673,16 +673,17 @@ public class AdaScript {
                 .copyArgument(ttl)
                 // --- ttl end ---
                 // --- certs start ---
-                //  certs       04 (Uint)
-                //                81 (Array)
-                //      cert1       83 (Array)
-                //        drepType    09 (Uint) - DRep Always Abstain
-                //        credential  82 (Array)
-                //          type        00 (Uint)
-                //          addrKH      58 (Byte) 1c [hash...]
-                //        abstain      81 (Array)
-                //                     02 (Uint)
-                .copyString("048183098200581c")
+                // 04                    // certificates
+                // d90102               // tag(258)
+                // 81                   // Array with length 1
+                //   83                 // Array with length 3
+                //     09              // DRep Always Abstain
+                //     82
+                //       00           // credential type
+                //       581c d5c85e06499c113db681255b6850f54ce0f889648193859399dbf50a  // stake key hash
+                //     81               // Array with length 1
+                //       02            // Always Abstain marker
+                .copyString("04d901028183098200581c")
                 .copyArgument(stakeKeyHash)
                 .copyString("8102")
                 // --- certs end ---

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/AdaScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/AdaScript.java
@@ -609,4 +609,90 @@ public class AdaScript {
 
     public static String ADATransactionScriptSignature = "0000304402202A93139827D7ED463320B2B9D31317EB71CB361FBA3612B7B5E363CAFCCD735C022037657AE592284219D45B236A34346FB797FC3290ED23593C836DDF95CB156CDC";
 
+    public static String getADADRepAbstainScript() {
+        ScriptArgumentComposer sac = new ScriptArgumentComposer();
+
+        ScriptData changeAddressLength = sac.getArgument(1);
+        ScriptData changeAddress = sac.getArgumentVariableLength(90);
+        ScriptData changeAmountLength = sac.getArgument(1);
+        ScriptData changeAmountPrefix = sac.getArgument(1);
+        ScriptData changeAmount = sac.getArgumentVariableLength(8);
+
+        ScriptData feeLength = sac.getArgument(1);
+        ScriptData feePrefix = sac.getArgument(1);
+        ScriptData fee = sac.getArgumentVariableLength(8);
+
+        ScriptData ttlLength = sac.getArgument(1);
+        ScriptData ttlPrefix = sac.getArgument(1);
+        ScriptData ttl = sac.getArgumentVariableLength(8);
+
+        ScriptData stakeKeyHash = sac.getArgument(28);
+
+        ScriptData inputs = sac.getArgumentAll();
+
+        String script = new ScriptAssembler()
+                .setCoinType(0x0717)
+                // -- payload start --
+                .copyString("a5")
+                // --- intput start ---
+                .copyArgument(inputs)
+                // --- intput end ---
+                // --- output start ---
+                .copyString("01")
+                .ifEqual(changeAmount, "0000000000000000",
+                    // ---- output count start ----
+                    new ScriptAssembler().copyString("80").getScript(),
+                    new ScriptAssembler().copyString("81")
+                    // ---- output count end ----
+                    // --- output change start ---
+                    .copyString("8258")
+                    .copyArgument(changeAddressLength)
+                    .setBufferInt(changeAddressLength, 29, 90)
+                    .copyArgument(changeAddress)
+                    .copyArgument(changeAmountPrefix)
+                    .setBufferInt(changeAmountLength, 0, 8)
+                    .copyArgument(changeAmount).getScript()
+                    // --- output change end ---
+                )
+                // --- output end ---
+                // --- fee start ---
+                .copyString("02")
+                .copyArgument(feePrefix)
+                .setBufferInt(feeLength, 0, 8)
+                .copyArgument(fee)
+                // --- fee end ---
+                //ttl         03 (Uint)
+                //            1a (Uint) 02126ed9
+
+                // --- ttl start ---
+                .copyString("03")
+                .copyArgument(ttlPrefix)
+                .setBufferInt(ttlLength, 0, 8)
+                .copyArgument(ttl)
+                // --- ttl end ---
+                // --- certs start ---
+                //  certs       04 (Uint)
+                //                81 (Array)
+                //      cert1       83 (Array)
+                //        drepType    09 (Uint) - DRep Always Abstain
+                //        credential  82 (Array)
+                //          type        00 (Uint)
+                //          addrKH      58 (Byte) 1c [hash...]
+                //        abstain      81 (Array)
+                //                     02 (Uint)
+                .copyString("048183098200581c")
+                .copyArgument(stakeKeyHash)
+                .copyString("8102")
+                // --- certs end ---
+
+                // -- payload end --
+                .showMessage("ADA")
+                .showMessage("Abstain")
+                .showPressButton()
+                // version=04 ScriptAssembler.hash=0E=ScriptAssembler.Blake2b256 sign=03=BIP32EDDSA
+                .setHeader(HashType.Blake2b256, SignType.BIP32EDDSA)
+                .getScript();
+        return script;
+    }
+
 }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/AdaScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/AdaScript.java
@@ -699,7 +699,7 @@ public class AdaScript {
     }
 
     public static String ADADRepAbstainScriptSignature = Strings.padStart(
-        "30450221009d0e8b78ae085fbdd428633a895e2a129b9d2260d6ea181301f170ad9f842c4502207899ac929bcb787a60219a13c34dd0da90f99205debb78115bc9cc5c2410ad9c",
+        "3044022009dc4cb3ae3657b1da1451d95198b96e0193a2d6afbe9616bc51cc45cb30d61002206658fada489dbb9c27ab3eb0c6da09ab24e7ea120224fd3ce0f6a9cae1c13e09",
         144,
         '0');
 

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/AdaScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/AdaScript.java
@@ -13,6 +13,7 @@ import com.coolbitx.wallet.signing.utils.ScriptAssembler.HashType;
 import com.coolbitx.wallet.signing.utils.ScriptAssembler.SignType;
 import com.coolbitx.wallet.signing.utils.ScriptData.Buffer;
 
+import com.google.common.base.Strings;
 // Address Encode Types
 //
 // 0: Byron address
@@ -32,6 +33,7 @@ public class AdaScript {
         System.out.println("ADA Stake Delegate: \n" + getADAStakeDelegateScript() + "\n");
         System.out.println("ADA Stake Deregister: \n" + getADAStakeDeregisterScript() + "\n");
         System.out.println("ADA Stake Withdraw: \n" + getADAStakeWithdrawScript() + "\n");
+        System.out.println("ADA DRep Abstain: \n" + getADADRepAbstainScript() + "\n");
     }
 
     public static String getShowAddressScript(ScriptData encodeType, ScriptData addrLen, ScriptData addrHex) {
@@ -694,5 +696,10 @@ public class AdaScript {
                 .getScript();
         return script;
     }
+
+    public static String ADADRepAbstainScriptSignature = Strings.padStart(
+        "30450221009d0e8b78ae085fbdd428633a895e2a129b9d2260d6ea181301f170ad9f842c4502207899ac929bcb787a60219a13c34dd0da90f99205debb78115bc9cc5c2410ad9c",
+        144,
+        '0');
 
 }


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR implements support for ADA DRep Abstain transactions by adding a new script generation function `getADADRepAbstainScript` in `AdaScript.java`.  This allows users to abstain from voting in DRep elections.

**Key Changes**
- Added `getADADRepAbstainScript` function to generate the transaction script.
- Included the necessary logic for handling change addresses, amounts, fees, TTL, and stake key hashes.
- Added a placeholder signature `ADADRepAbstainScriptSignature`.
- Added abstain certificate construction within the script.

**Recommendations**
Ready for merge after unit tests are added to verify the generated script and signature.  Consider adding integration tests to validate the end-to-end flow of an abstain transaction.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>