### PR TITLE
fix(XTZ): CW-26454 tezos reveal failed

### DIFF
--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XtzScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XtzScript.java
@@ -5,15 +5,19 @@
  */
 package com.coolbitx.wallet.signing.scriptlib;
 
+import com.coolbitx.wallet.signing.utils.HexUtil;
 import com.coolbitx.wallet.signing.utils.ScriptArgumentComposer;
 import com.coolbitx.wallet.signing.utils.ScriptAssembler;
-import com.coolbitx.wallet.signing.utils.ScriptData;
 import com.coolbitx.wallet.signing.utils.ScriptAssembler.HashType;
 import com.coolbitx.wallet.signing.utils.ScriptAssembler.SignType;
+import com.coolbitx.wallet.signing.utils.ScriptData;
 import com.coolbitx.wallet.signing.utils.ScriptData.Buffer;
-import com.coolbitx.wallet.signing.utils.HexUtil;
 
 public class XtzScript {
+
+    public static void main(String[] args) throws Exception {
+        listAll();
+    }
 
     public static void listAll() {
         System.out.println("XTZ Reveal: \n" + getTezosRevealScript() + "\n");
@@ -63,6 +67,8 @@ public class XtzScript {
                 .protobuf(argStorageLimit, typeInt)
                 // public key (33 Bytes)
                 .copyArgument(argPublicKey)
+                // presence_of_proof = false (no proof for non-tz4)
+                .copyString("00")
                 // Step 4. Define which parts of the arguments shall be showed on the screen to be validated.
                 .showMessage("XTZ")
                 .showMessage("Reveal")


### PR DESCRIPTION
the issue from cs:
https://coolbitx.slack.com/archives/CREBU3Y9J/p1766720064807399
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a Tezos reveal transaction failure by modifying the reveal script to correctly handle the `presence_of_proof` field.

#### Key Changes
- Added `copyString("00")` to the Tezos reveal script, explicitly setting `presence_of_proof` to false for non-tz4 accounts.
- Reordered import statements.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 6 (75.0%)     |
| Refactor    | 2 (25.0%)     |
| Total Changes | 8             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>