### PR TITLE
feat(ZEC): CW-26066 support zcash

### DIFF
--- a/.vscode/java-formatter.xml
+++ b/.vscode/java-formatter.xml
@@ -2,18 +2,24 @@
 <profiles version="21">
   <profile kind="CodeFormatterProfile" name="CoolWalletJavaStyle" version="21">
     <!-- 使用空白，不用 tab -->
-    <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+    <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space" />
     <!-- 每階層縮排 4 -->
-    <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
-    <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+    <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4" />
+    <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4" />
 
     <!-- 【關鍵】延續縮排（換行時）用 1 個縮排單位（=4），避免變成 8 -->
-    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="1"/>
-    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="1" />
+    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer"
+      value="1" />
+
+    <!-- Chained method calls wrapping: Wrap all elements, every element on a new line, Force split
+    (80 = 16 | 64) -->
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation"
+      value="80" />
 
     <!-- 其他常見偏好，可按需調整 -->
-    <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="true"/>
-    <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
-    <setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+    <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="true" />
+    <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true" />
+    <setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true" />
   </profile>
 </profiles>

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/KasScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/KasScript.java
@@ -14,224 +14,166 @@ import com.google.common.base.Strings;
 
 public class KasScript {
 
-        public static void main(String[] args) {
-                listAll();
+    public static void main(String[] args) {
+        listAll();
+    }
+
+    public static void listAll() {
+        System.out.println("Kas transfer: \n" + getTransferScript(false) + "\n");
+    }
+
+    public static String getAddressScript(ScriptData argOutputScriptType,
+        ScriptData argOutputXOnlyPublicKeyOrScriptHash, ScriptData argOutputPublicKey) {
+        String hrp = "kaspa";
+        String hrpExpand = "";
+        for (int i = 0; i < hrp.length(); i++) {
+            hrpExpand += HexUtil.toHexString(hrp.charAt(i) & 31, 1);
         }
+        hrpExpand += "00";
+        String bech32AddressScript = new ScriptAssembler().clearBuffer(Buffer.CACHE1).clearBuffer(Buffer.CACHE2)
+            .copyString(hrpExpand, Buffer.CACHE2).switchString(argOutputScriptType, Buffer.CACHE1, "00,01,08")
+            .ifEqual(argOutputScriptType, "01",
+                // addressVersion + outputPublicKey -> cache1
+                new ScriptAssembler().copyArgument(argOutputPublicKey, Buffer.CACHE1).getScript(),
+                // addressVersion + outputXOnlyPublicKeyOrScriptHash -> cache1
+                new ScriptAssembler().copyArgument(argOutputXOnlyPublicKeyOrScriptHash, Buffer.CACHE1).getScript())
+            .ifEqual(argOutputScriptType, "01",
+                // 34 * 8 / 5 = 54.4 ≈ 55
+                // convert8To5Bits(version + outputPublicKey) -> cache2
+                new ScriptAssembler().baseConvert(ScriptData.getDataBufferAll(Buffer.CACHE1), Buffer.CACHE2, 55,
+                    ScriptAssembler.binary32Charset, ScriptAssembler.bitLeftJustify8to5).getScript(),
+                // 33 * 8 / 5 = 52.8 ≈ 53
+                // convert8To5Bits(addressVersion + outputXOnlyPublicKeyOrScriptHash) ->
+                // cache2
+                new ScriptAssembler().baseConvert(ScriptData.getDataBufferAll(Buffer.CACHE1), Buffer.CACHE2, 53,
+                    ScriptAssembler.binary32Charset, ScriptAssembler.bitLeftJustify8to5).getScript())
+            .copyString("0000000000000000", Buffer.CACHE2)
+            // calculate checksum -> cache1
+            .bchPolymod(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE1).clearBuffer(Buffer.CACHE2)
+            .ifEqual(argOutputScriptType, "01",
+                // bech32(convert8To5Bits(addressVersion + outputPublicKey)) -> cache2
+                // bech32(convert8To5Bits(checksum)) -> cache2
+                new ScriptAssembler()
+                    .baseConvert(ScriptData.getBuffer(Buffer.CACHE1, 0, 34), Buffer.CACHE2, 55,
+                        ScriptAssembler.base32BitcoinCashCharset, ScriptAssembler.bitLeftJustify8to5)
+                    .baseConvert(ScriptData.getDataBufferAll(Buffer.CACHE1, 34), Buffer.CACHE2, 8,
+                        ScriptAssembler.base32BitcoinCashCharset, ScriptAssembler.bitLeftJustify8to5)
+                    .getScript(),
+                // bech32(convert8To5Bits(addressVersion +
+                // outputXOnlyPublicKeyOrScriptHash)) -> cache2
+                // bech32(convert8To5Bits(checksum)) -> cache2
+                new ScriptAssembler()
+                    .baseConvert(ScriptData.getBuffer(Buffer.CACHE1, 0, 33), Buffer.CACHE2, 53,
+                        ScriptAssembler.base32BitcoinCashCharset, ScriptAssembler.bitLeftJustify8to5)
+                    .baseConvert(ScriptData.getDataBufferAll(Buffer.CACHE1, 33), Buffer.CACHE2, 8,
+                        ScriptAssembler.base32BitcoinCashCharset, ScriptAssembler.bitLeftJustify8to5)
+                    .getScript())
+            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2)).getScript();
+        return bech32AddressScript;
+    }
 
-        public static void listAll() {
-                System.out.println("Kas transfer: \n" + getTransferScript(false) + "\n");
-        }
+    /**
+     * 0000 // transaction version
+     * b9040cd6c2cc517e2684744b61b9defaeb670312759d8a778007ab72c5d06e02 //
+     * previousOutputsHash
+     * 0f99135614633e507969d12522c80f967cff6ebc0436863e02ee42b2b66556fc //
+     * sequencesHash
+     * 8523b0471bcbea04575ccaa635eef9f9114f2890bda54367e5ff8caa3878bf82 //
+     * sigOpCountsHash 00000000 // zeroPadding 13 // hashType 0068 //
+     * totalOutputsLength 00/01/02 // outputScriptType
+     * 000a3da6e8c7a8795440e60e4662686bc17cd965780095604c85d8d137e0f48079 //
+     * outputPublicKeyOrScriptHash e803000000000000 // outputReverseAmount 0000
+     * // outputReverseScriptVersion 2200000000000000 //
+     * outputScriptPublicKeyReverseLength 01 // haveChange 22c8668c00000000 //
+     * changeReverseAmount 0016 // hashKey length
+     * 5472616e73616374696f6e5369676e696e6748617368 // hashKey:
+     * TransactionSigningHash 328000002c8001b207800000000000000000000000 //
+     * sePath 0000000000000000 // reverseLockTime
+     * 0000000000000000000000000000000000000000 // subNetworkId 0000000000000000
+     * // reverseGas
+     * 0000000000000000000000000000000000000000000000000000000000000000 //
+     * payload 01 // signType
+     *
+     */
+    public static String getTransferScript(boolean isTestnet) {
+        ScriptArgumentComposer sac = new ScriptArgumentComposer();
+        ScriptData argReverseVersion = sac.getArgument(2);
+        ScriptData argHashPrevouts = sac.getArgument(32);
+        ScriptData argHashSequences = sac.getArgument(32);
+        ScriptData argHashSigOpCount = sac.getArgument(32);
+        ScriptData argZeroPadding = sac.getArgument(4); // workaround for utxoDataPlaceholder
+        ScriptData argNewHashType = sac.getArgument(1);
+        ScriptData argHashOutLength = sac.getArgument(2);
 
-        public static String getAddressScript(
-                        ScriptData argOutputScriptType,
-                        ScriptData argOutputXOnlyPublicKeyOrScriptHash,
-                        ScriptData argOutputPublicKey) {
-                String hrp = "kaspa";
-                String hrpExpand = "";
-                for (int i = 0; i < hrp.length(); i++) {
-                        hrpExpand += HexUtil.toHexString(hrp.charAt(i) & 31, 1);
-                }
-                hrpExpand += "00";
-                String bech32AddressScript = new ScriptAssembler()
-                                .clearBuffer(Buffer.CACHE1)
-                                .clearBuffer(Buffer.CACHE2)
-                                .copyString(hrpExpand, Buffer.CACHE2)
-                                .switchString(argOutputScriptType, Buffer.CACHE1, "00,01,08")
-                                .ifEqual(argOutputScriptType, "01",
-                                                // addressVersion + outputPublicKey -> cache1
-                                                new ScriptAssembler().copyArgument(
-                                                                argOutputPublicKey,
-                                                                Buffer.CACHE1).getScript(),
-                                                // addressVersion + outputXOnlyPublicKeyOrScriptHash -> cache1
-                                                new ScriptAssembler().copyArgument(
-                                                                argOutputXOnlyPublicKeyOrScriptHash,
-                                                                Buffer.CACHE1).getScript())
-                                .ifEqual(argOutputScriptType, "01",
-                                                // 34 * 8 / 5 = 54.4 ≈ 55
-                                                // convert8To5Bits(version + outputPublicKey) -> cache2
-                                                new ScriptAssembler().baseConvert(
-                                                                ScriptData.getDataBufferAll(Buffer.CACHE1),
-                                                                Buffer.CACHE2,
-                                                                55,
-                                                                ScriptAssembler.binary32Charset,
-                                                                ScriptAssembler.bitLeftJustify8to5).getScript(),
-                                                // 33 * 8 / 5 = 52.8 ≈ 53
-                                                // convert8To5Bits(addressVersion + outputXOnlyPublicKeyOrScriptHash) ->
-                                                // cache2
-                                                new ScriptAssembler().baseConvert(
-                                                                ScriptData.getDataBufferAll(Buffer.CACHE1),
-                                                                Buffer.CACHE2,
-                                                                53,
-                                                                ScriptAssembler.binary32Charset,
-                                                                ScriptAssembler.bitLeftJustify8to5).getScript())
-                                .copyString("0000000000000000", Buffer.CACHE2)
-                                // calculate checksum -> cache1
-                                .bchPolymod(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE1)
-                                .clearBuffer(Buffer.CACHE2)
-                                .ifEqual(argOutputScriptType, "01",
-                                                // bech32(convert8To5Bits(addressVersion + outputPublicKey)) -> cache2
-                                                // bech32(convert8To5Bits(checksum)) -> cache2
-                                                new ScriptAssembler().baseConvert(
-                                                                ScriptData.getBuffer(Buffer.CACHE1, 0, 34),
-                                                                Buffer.CACHE2,
-                                                                55,
-                                                                ScriptAssembler.base32BitcoinCashCharset,
-                                                                ScriptAssembler.bitLeftJustify8to5)
-                                                                .baseConvert(
-                                                                                ScriptData.getDataBufferAll(
-                                                                                                Buffer.CACHE1, 34),
-                                                                                Buffer.CACHE2,
-                                                                                8,
-                                                                                ScriptAssembler.base32BitcoinCashCharset,
-                                                                                ScriptAssembler.bitLeftJustify8to5)
-                                                                .getScript(),
-                                                // bech32(convert8To5Bits(addressVersion +
-                                                // outputXOnlyPublicKeyOrScriptHash)) -> cache2
-                                                // bech32(convert8To5Bits(checksum)) -> cache2
-                                                new ScriptAssembler().baseConvert(
-                                                                ScriptData.getBuffer(Buffer.CACHE1, 0, 33),
-                                                                Buffer.CACHE2,
-                                                                53,
-                                                                ScriptAssembler.base32BitcoinCashCharset,
-                                                                ScriptAssembler.bitLeftJustify8to5).baseConvert(
-                                                                                ScriptData.getDataBufferAll(
-                                                                                                Buffer.CACHE1, 33),
-                                                                                Buffer.CACHE2,
-                                                                                8,
-                                                                                ScriptAssembler.base32BitcoinCashCharset,
-                                                                                ScriptAssembler.bitLeftJustify8to5)
-                                                                .getScript())
-                                .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2))
-                                .getScript();
-                return bech32AddressScript;
-        }
+        ScriptData argOutputScriptType = sac.getArgument(1);
+        ScriptData argOutputXOnlyPublicKeyOrScriptHash = sac.getArgumentUnion(1, 32);
+        ScriptData argOutputPublicKey = sac.getArgument(33);
+        String addressScript = getAddressScript(argOutputScriptType, argOutputXOnlyPublicKeyOrScriptHash,
+            argOutputPublicKey);
 
-        /**
-         * 0000 // transaction version
-         * b9040cd6c2cc517e2684744b61b9defaeb670312759d8a778007ab72c5d06e02 //
-         * previousOutputsHash
-         * 0f99135614633e507969d12522c80f967cff6ebc0436863e02ee42b2b66556fc //
-         * sequencesHash
-         * 8523b0471bcbea04575ccaa635eef9f9114f2890bda54367e5ff8caa3878bf82 //
-         * sigOpCountsHash 00000000 // zeroPadding 13 // hashType 0068 //
-         * totalOutputsLength 00/01/02 // outputScriptType
-         * 000a3da6e8c7a8795440e60e4662686bc17cd965780095604c85d8d137e0f48079 //
-         * outputPublicKeyOrScriptHash e803000000000000 // outputReverseAmount 0000
-         * // outputReverseScriptVersion 2200000000000000 //
-         * outputScriptPublicKeyReverseLength 01 // haveChange 22c8668c00000000 //
-         * changeReverseAmount 0016 // hashKey length
-         * 5472616e73616374696f6e5369676e696e6748617368 // hashKey:
-         * TransactionSigningHash 328000002c8001b207800000000000000000000000 //
-         * sePath 0000000000000000 // reverseLockTime
-         * 0000000000000000000000000000000000000000 // subNetworkId 0000000000000000
-         * // reverseGas
-         * 0000000000000000000000000000000000000000000000000000000000000000 //
-         * payload 01 // signType
-         *
-         */
-        public static String getTransferScript(boolean isTestnet) {
-                ScriptArgumentComposer sac = new ScriptArgumentComposer();
-                ScriptData argReverseVersion = sac.getArgument(2);
-                ScriptData argHashPrevouts = sac.getArgument(32);
-                ScriptData argHashSequences = sac.getArgument(32);
-                ScriptData argHashSigOpCount = sac.getArgument(32);
-                ScriptData argZeroPadding = sac.getArgument(4); // workaround for utxoDataPlaceholder
-                ScriptData argNewHashType = sac.getArgument(1);
-                ScriptData argHashOutLength = sac.getArgument(2);
+        ScriptData argReverseOutputAmount = sac.getArgument(8);
+        ScriptData argReverseOutputScriptionVersion = sac.getArgument(2);
+        ScriptData argReverseOutputScriptPublicKeyLength = sac.getArgument(8);
 
-                ScriptData argOutputScriptType = sac.getArgument(1);
-                ScriptData argOutputXOnlyPublicKeyOrScriptHash = sac.getArgumentUnion(1, 32);
-                ScriptData argOutputPublicKey = sac.getArgument(33);
-                String addressScript = getAddressScript(argOutputScriptType, argOutputXOnlyPublicKeyOrScriptHash,
-                                argOutputPublicKey);
+        ScriptData argHaveChange = sac.getArgument(1);
+        ScriptData argReverseChangeAmount = sac.getArgument(8);
+        ScriptData argHashKeyLength = sac.getArgument(2);
+        ScriptData argHashKey = sac.getArgument(22);
+        ScriptData argChangePath = sac.getArgument(21);
+        ScriptData argReverseLockTime = sac.getArgument(8);
+        ScriptData argSubNetwokId = sac.getArgument(20);
+        ScriptData argReverseGas = sac.getArgument(8);
+        ScriptData argPayload = sac.getArgument(32);
+        ScriptData argHashType = sac.getArgument(1);
 
-                ScriptData argReverseOutputAmount = sac.getArgument(8);
-                ScriptData argReverseOutputScriptionVersion = sac.getArgument(2);
-                ScriptData argReverseOutputScriptPublicKeyLength = sac.getArgument(8);
+        String script = new ScriptAssembler().setCoinType(0x1b207)
+            // AllHash
+            .copyArgument(argReverseVersion).copyArgument(argHashPrevouts).copyArgument(argHashSequences)
+            .copyArgument(argHashSigOpCount).utxoDataPlaceholder(argZeroPadding)
+            // Output
+            .copyArgument(argNewHashType, Buffer.CACHE1).copyArgument(argHashOutLength, Buffer.CACHE1)
+            .copyArgument(argReverseOutputAmount, Buffer.CACHE1)
+            .copyArgument(argReverseOutputScriptionVersion, Buffer.CACHE1)
+            .copyArgument(argReverseOutputScriptPublicKeyLength, Buffer.CACHE1)
+            // ScriptPublicKey Rules:
+            // 1. Output script types:
+            // - 00: 20 + X-only Public key + AC
+            // - 01: 21 + public key + AB
+            // - 02: AA20 + Script hash + 87
+            // 2. Copy the corresponding public key or script hash to CACHE1 buffer
+            .switchString(argOutputScriptType, Buffer.CACHE1, "20,21,AA20")
+            .ifEqual(argOutputScriptType, "01",
+                new ScriptAssembler().copyArgument(argOutputPublicKey, Buffer.CACHE1).getScript(),
+                new ScriptAssembler().copyArgument(argOutputXOnlyPublicKeyOrScriptHash, Buffer.CACHE1).getScript())
+            .switchString(argOutputScriptType, Buffer.CACHE1, "AC,AB,87")
+            // if haveChange derive change address
+            .ifEqual(argHaveChange, "01",
+                new ScriptAssembler().copyArgument(argReverseChangeAmount, Buffer.CACHE1)
+                    .copyArgument(argReverseOutputScriptionVersion, Buffer.CACHE1)
+                    // Change script publicKey length
+                    .copyString("2200000000000000", Buffer.CACHE1)
+                    // Script publicKey prefix
+                    .copyString("20", Buffer.CACHE1).derivePublicKey(argChangePath, Buffer.CACHE2)
+                    // To x only public key
+                    .copyArgument(ScriptData.getBuffer(Buffer.CACHE2, 1, 32), Buffer.CACHE1).clearBuffer(Buffer.CACHE2)
+                    // Script publicKey end
+                    .copyString("ac", Buffer.CACHE1).getScript(),
+                "")
+            // blake2b hash all outputs
+            .copyArgument(argHashKeyLength, Buffer.CACHE1).copyArgument(argHashKey, Buffer.CACHE1)
+            .newHash(ScriptData.getDataBufferAll(Buffer.CACHE1), Buffer.TRANSACTION,
+                ScriptAssembler.HashType.Blake2b256Mac)
+            .copyArgument(argReverseLockTime).copyArgument(argSubNetwokId).copyArgument(argReverseGas)
+            .copyArgument(argPayload).copyArgument(argHashType).showMessage("KAS").insertString(addressScript)
+            .clearBuffer(Buffer.CACHE1)
+            .baseConvert(argReverseOutputAmount, Buffer.CACHE1, 8, ScriptAssembler.binaryCharset,
+                ScriptAssembler.littleEndian)
+            .showAmount(ScriptData.getDataBufferAll(Buffer.CACHE1), 8).clearBuffer(Buffer.CACHE1).showPressButton()
+            .setHeader(ScriptAssembler.HashType.Blake2b256Mac, ScriptAssembler.SignType.SCHNORR).getScript();
+        return script;
+    }
 
-                ScriptData argHaveChange = sac.getArgument(1);
-                ScriptData argReverseChangeAmount = sac.getArgument(8);
-                ScriptData argHashKeyLength = sac.getArgument(2);
-                ScriptData argHashKey = sac.getArgument(22);
-                ScriptData argChangePath = sac.getArgument(21);
-                ScriptData argReverseLockTime = sac.getArgument(8);
-                ScriptData argSubNetwokId = sac.getArgument(20);
-                ScriptData argReverseGas = sac.getArgument(8);
-                ScriptData argPayload = sac.getArgument(32);
-                ScriptData argHashType = sac.getArgument(1);
-
-                String script = new ScriptAssembler()
-                                .setCoinType(0x1b207)
-                                // AllHash
-                                .copyArgument(argReverseVersion)
-                                .copyArgument(argHashPrevouts)
-                                .copyArgument(argHashSequences)
-                                .copyArgument(argHashSigOpCount)
-                                .utxoDataPlaceholder(argZeroPadding)
-                                // Output
-                                .copyArgument(argNewHashType, Buffer.CACHE1)
-                                .copyArgument(argHashOutLength, Buffer.CACHE1)
-                                .copyArgument(argReverseOutputAmount, Buffer.CACHE1)
-                                .copyArgument(argReverseOutputScriptionVersion, Buffer.CACHE1)
-                                .copyArgument(argReverseOutputScriptPublicKeyLength, Buffer.CACHE1)
-                                // ScriptPublicKey Rules:
-                                // 1. Output script types:
-                                // - 00: 20 + X-only Public key + AC
-                                // - 01: 21 + public key + AB
-                                // - 02: AA20 + Script hash + 87
-                                // 2. Copy the corresponding public key or script hash to CACHE1 buffer
-                                .switchString(argOutputScriptType, Buffer.CACHE1, "20,21,AA20")
-                                .ifEqual(argOutputScriptType, "01",
-                                                new ScriptAssembler().copyArgument(
-                                                                argOutputPublicKey,
-                                                                Buffer.CACHE1).getScript(),
-                                                new ScriptAssembler().copyArgument(
-                                                                argOutputXOnlyPublicKeyOrScriptHash,
-                                                                Buffer.CACHE1).getScript())
-                                .switchString(argOutputScriptType, Buffer.CACHE1, "AC,AB,87")
-                                // if haveChange derive change address
-                                .ifEqual(argHaveChange, "01",
-                                                new ScriptAssembler()
-                                                                .copyArgument(argReverseChangeAmount, Buffer.CACHE1)
-                                                                .copyArgument(argReverseOutputScriptionVersion,
-                                                                                Buffer.CACHE1)
-                                                                // Change script publicKey length
-                                                                .copyString("2200000000000000", Buffer.CACHE1)
-                                                                // Script publicKey prefix
-                                                                .copyString("20", Buffer.CACHE1)
-                                                                .derivePublicKey(argChangePath, Buffer.CACHE2)
-                                                                // To x only public key
-                                                                .copyArgument(ScriptData.getBuffer(Buffer.CACHE2, 1,
-                                                                                32), Buffer.CACHE1)
-                                                                .clearBuffer(Buffer.CACHE2)
-                                                                // Script publicKey end
-                                                                .copyString("ac", Buffer.CACHE1)
-                                                                .getScript(),
-                                                "")
-                                // blake2b hash all outputs
-                                .copyArgument(argHashKeyLength, Buffer.CACHE1)
-                                .copyArgument(argHashKey, Buffer.CACHE1)
-                                .newHash(ScriptData.getDataBufferAll(Buffer.CACHE1), Buffer.TRANSACTION,
-                                                ScriptAssembler.HashType.Blake2b256Mac)
-                                .copyArgument(argReverseLockTime)
-                                .copyArgument(argSubNetwokId)
-                                .copyArgument(argReverseGas)
-                                .copyArgument(argPayload)
-                                .copyArgument(argHashType)
-                                .showMessage("KAS")
-                                .insertString(addressScript)
-                                .clearBuffer(Buffer.CACHE1)
-                                .baseConvert(argReverseOutputAmount, Buffer.CACHE1, 8, ScriptAssembler.binaryCharset,
-                                                ScriptAssembler.littleEndian)
-                                .showAmount(ScriptData.getDataBufferAll(Buffer.CACHE1), 8)
-                                .clearBuffer(Buffer.CACHE1)
-                                .showPressButton()
-                                .setHeader(ScriptAssembler.HashType.Blake2b256Mac, ScriptAssembler.SignType.SCHNORR)
-                                .getScript();
-                return script;
-        }
-
-        public static String KASScriptSignature = Strings.padStart(
-                        "3045022018eeb3dc55bf632fc93c2bf7007a70a58b2312cfeb2ed4b26bccd5128d855f08022100af0e14aadfd7503082bec1649d8396f1438d748b5f5461e1e9b6f40d3161c0a4",
-                        144, '0');
+    public static String KASScriptSignature = Strings.padStart(
+        "3045022018eeb3dc55bf632fc93c2bf7007a70a58b2312cfeb2ed4b26bccd5128d855f08022100af0e14aadfd7503082bec1649d8396f1438d748b5f5461e1e9b6f40d3161c0a4",
+        144, '0');
 }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/KasScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/KasScript.java
@@ -162,14 +162,14 @@ public class KasScript {
             // blake2b hash all outputs
             .copyArgument(argHashKeyLength, Buffer.CACHE1).copyArgument(argHashKey, Buffer.CACHE1)
             .newHash(ScriptData.getDataBufferAll(Buffer.CACHE1), Buffer.TRANSACTION,
-                ScriptAssembler.HashType.Blake2b256Mac)
+                ScriptAssembler.AdvancedHashType.Blake2b256Mac)
             .copyArgument(argReverseLockTime).copyArgument(argSubNetwokId).copyArgument(argReverseGas)
             .copyArgument(argPayload).copyArgument(argHashType).showMessage("KAS").insertString(addressScript)
             .clearBuffer(Buffer.CACHE1)
             .baseConvert(argReverseOutputAmount, Buffer.CACHE1, 8, ScriptAssembler.binaryCharset,
                 ScriptAssembler.littleEndian)
             .showAmount(ScriptData.getDataBufferAll(Buffer.CACHE1), 8).clearBuffer(Buffer.CACHE1).showPressButton()
-            .setHeader(ScriptAssembler.HashType.Blake2b256Mac, ScriptAssembler.SignType.SCHNORR).getScript();
+            .setHeader(ScriptAssembler.AdvancedHashType.Blake2b256Mac, ScriptAssembler.SignType.SCHNORR).getScript();
         return script;
     }
 

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -18,8 +18,13 @@ import com.google.common.base.Strings;
 
 public class XrpScript {
 
+    public static void main(String[] args) {
+        listAll();
+    }
+
     public static void listAll() {
         System.out.println("Xrp: \n" + getXRPScript() + "\n");
+        System.out.println("Xrp RLP: \n" + getXRPRlpArgumentScript() + "\n");
     }
 
     public static String getXRPScript() {
@@ -36,19 +41,38 @@ public class XrpScript {
         ScriptData argTag = sac.getArgument(4);
         ScriptData argFlags = sac.getArgument(4);
 
-        String script = new ScriptAssembler().setCoinType(0x90).copyString("5354580012000022").copyArgument(argFlags)
-            .copyString("24").copyArgument(argSequence).copyString("2E").copyArgument(argTag).copyString("201B")
-            .copyArgument(argLastLedgerSequence).copyString("6140").copyArgument(argAmount).copyString("6840")
-            .copyArgument(argFee).copyString("7321").copyArgument(argPublicKey).copyString("8114")
-            .copyArgument(argAccount).copyString("8314").copyArgument(argDest).showMessage("XRP")
-            .copyString("00", Buffer.CACHE2).copyArgument(argDest, Buffer.CACHE2)
+        String script = new ScriptAssembler().setCoinType(0x90)
+            .copyString("5354580012000022")
+            .copyArgument(argFlags)
+            .copyString("24")
+            .copyArgument(argSequence)
+            .copyString("2E")
+            .copyArgument(argTag)
+            .copyString("201B")
+            .copyArgument(argLastLedgerSequence)
+            .copyString("6140")
+            .copyArgument(argAmount)
+            .copyString("6840")
+            .copyArgument(argFee)
+            .copyString("7321")
+            .copyArgument(argPublicKey)
+            .copyString("8114")
+            .copyArgument(argAccount)
+            .copyString("8314")
+            .copyArgument(argDest)
+            .showMessage("XRP")
+            .copyString("00", Buffer.CACHE2)
+            .copyArgument(argDest, Buffer.CACHE2)
             .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
             .copyString(HexUtil.toHexString("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
                 Buffer.CACHE1)
             .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE2, 45, ScriptAssembler.cache1Charset,
                 ScriptAssembler.zeroInherit)
-            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53)).showAmount(argAmount, 6).showPressButton()
-            .setHeader(HashType.SHA512, SignType.ECDSA).getScript();
+            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53))
+            .showAmount(argAmount, 6)
+            .showPressButton()
+            .setHeader(HashType.SHA512, SignType.ECDSA)
+            .getScript();
         return script;
     }
 
@@ -66,19 +90,38 @@ public class XrpScript {
         ScriptRlpData argTag = array.getRlpItemArgument();
         ScriptRlpData argFlags = array.getRlpItemArgument();
 
-        String script = new ScriptAssembler().setCoinType(0x90).copyString("5354580012000022").copyArgument(argFlags)
-            .copyString("24").copyArgument(argSequence).copyString("2E").copyArgument(argTag).copyString("201B")
-            .copyArgument(argLastLedgerSequence).copyString("6140").copyArgument(argAmount).copyString("6840")
-            .copyArgument(argFee).copyString("7321").copyArgument(argPublicKey).copyString("8114")
-            .copyArgument(argAccount).copyString("8314").copyArgument(argDest).showMessage("XRP")
-            .copyString("00", Buffer.CACHE2).copyArgument(argDest, Buffer.CACHE2)
+        String script = new ScriptAssembler().setCoinType(0x90)
+            .copyString("5354580012000022")
+            .copyArgument(argFlags)
+            .copyString("24")
+            .copyArgument(argSequence)
+            .copyString("2E")
+            .copyArgument(argTag)
+            .copyString("201B")
+            .copyArgument(argLastLedgerSequence)
+            .copyString("6140")
+            .copyArgument(argAmount)
+            .copyString("6840")
+            .copyArgument(argFee)
+            .copyString("7321")
+            .copyArgument(argPublicKey)
+            .copyString("8114")
+            .copyArgument(argAccount)
+            .copyString("8314")
+            .copyArgument(argDest)
+            .showMessage("XRP")
+            .copyString("00", Buffer.CACHE2)
+            .copyArgument(argDest, Buffer.CACHE2)
             .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
             .copyString(HexUtil.toHexString("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
                 Buffer.CACHE1)
             .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE2, 45, ScriptAssembler.cache1Charset,
                 ScriptAssembler.zeroInherit)
-            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53)).showAmount(argAmount, 6).showPressButton()
-            .setHeader(HashType.SHA512, SignType.ECDSA).getScript();
+            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53))
+            .showAmount(argAmount, 6)
+            .showPressButton()
+            .setHeader(HashType.SHA512, SignType.ECDSA)
+            .getScript();
         return script;
     }
 

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/ZcashScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/ZcashScript.java
@@ -29,7 +29,7 @@ public class ZcashScript {
             .switchString(argOutputScriptType, Buffer.CACHE2, !isTestnet ? "1CB8,1CBD" : "1D25,1CBA") // t1,t3:tm,t2
             .copyArgument(argOutputDest, Buffer.CACHE2)
             .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, ScriptAssembler.HashType.DoubleSHA256)
-            .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE1, 0, ScriptAssembler.base58Charset,
+            .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 26), Buffer.CACHE1, 0, ScriptAssembler.base58Charset,
                 ScriptAssembler.zeroInherit)
             .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE1))
             .getScript();
@@ -50,6 +50,7 @@ public class ZcashScript {
         ScriptRlpData argChangeAmount = array.getRlpItemArgument();
         ScriptRlpData argChangeScriptType = array.getRlpItemArgument();
         ScriptRlpData argChangePath = array.getRlpItemArgument();
+        ScriptRlpData argOutputHashPersonal = array.getRlpItemArgument();
 
         ScriptRlpData argLockTime = array.getRlpItemArgument();
         ScriptRlpData argExpiryHeight = array.getRlpItemArgument();
@@ -57,12 +58,11 @@ public class ZcashScript {
 
         String addressScript = getAddressScript(isTestnet, argOutputScriptType, argOutputDest);
 
-        String script = new ScriptAssembler().setCoinType(0x00)
+        String script = new ScriptAssembler().setCoinType(0x85)
             .copyArgument(argReverseVersion)
             .copyArgument(argReverseGroupId)
             .copyArgument(argHashPrevouts)
             .copyArgument(argHashSequences)
-
             .baseConvert(argOutputAmount, Buffer.CACHE1, 8, ScriptAssembler.binaryCharset, ScriptAssembler.littleEndian)
             // switch redeemScript P2PKH=00,P2SH=01
             .switchString(argOutputScriptType, Buffer.CACHE1, "1976A914,17A914")
@@ -85,7 +85,8 @@ public class ZcashScript {
                     .copyString("88AC", Buffer.CACHE1)
                     .getScript(),
                 "")
-            .hash(ScriptData.getDataBufferAll(Buffer.CACHE1), Buffer.TRANSACTION, ScriptAssembler.HashType.DoubleSHA256)
+            .advancedHash(ScriptData.getDataBufferAll(Buffer.CACHE1), argOutputHashPersonal, Buffer.TRANSACTION,
+                ScriptAssembler.AdvancedHashType.Blake2b256Personal)
             .copyString("0000000000000000000000000000000000000000000000000000000000000000") // Hash JoinSplits
             .copyString("0000000000000000000000000000000000000000000000000000000000000000") // Hash ShieldedSpends
             .copyString("0000000000000000000000000000000000000000000000000000000000000000") // Hash ShieldedOutputs
@@ -100,7 +101,7 @@ public class ZcashScript {
             .insertString(addressScript)
             .showAmount(argOutputAmount, 8)
             .showPressButton()
-            .setHeader(ScriptAssembler.HashType.DoubleSHA256, ScriptAssembler.SignType.ECDSA)
+            .setHeader(ScriptAssembler.AdvancedHashType.Blake2b256Personal, ScriptAssembler.SignType.ECDSA)
             .getScript();
         return script;
     }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/ZcashScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/ZcashScript.java
@@ -20,7 +20,7 @@ public class ZcashScript {
     }
 
     public static void listAll() {
-        System.out.println("Zcash witness 0: \n" + getZECScript(false) + "\n");
+        System.out.println("Zcash transparent transaction: \n" + getZECScript(false) + "\n");
     }
 
     public static String getAddressScript(boolean isTestnet, ScriptObjectAbstract argOutputScriptType,
@@ -106,6 +106,6 @@ public class ZcashScript {
         return script;
     }
 
-    public static String ZECScriptSignature = Strings.padEnd("FA", 144, '0');
+    public static String ZECScriptSignature = Strings.padStart("3046022100a3204ca844ac7f31333226607b1c86a71940850ef75d4cb7ad25b4fd49cef0ba022100d6b6d7fd5aec8e77a837ec70a7a7419b343a49b0dfa6263c8b6ad196cc32e90d", 144, '0');
 
 }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/ZcashScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/ZcashScript.java
@@ -1,0 +1,110 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.coolbitx.wallet.signing.scriptlib;
+
+import com.coolbitx.wallet.signing.utils.ScriptAssembler;
+import com.coolbitx.wallet.signing.utils.ScriptData;
+import com.coolbitx.wallet.signing.utils.ScriptData.Buffer;
+import com.coolbitx.wallet.signing.utils.ScriptObjectAbstract;
+import com.coolbitx.wallet.signing.utils.ScriptRlpArray;
+import com.coolbitx.wallet.signing.utils.ScriptRlpData;
+import com.google.common.base.Strings;
+
+public class ZcashScript {
+
+    public static void main(String[] args) {
+        listAll();
+    }
+
+    public static void listAll() {
+        System.out.println("Zcash witness 0: \n" + getZECScript(false) + "\n");
+    }
+
+    public static String getAddressScript(boolean isTestnet, ScriptObjectAbstract argOutputScriptType,
+        ScriptObjectAbstract argOutputDest) {
+        String addressScript = new ScriptAssembler()
+            .switchString(argOutputScriptType, Buffer.CACHE2, !isTestnet ? "1CB8,1CBD" : "1D25,1CBA") // t1,t3:tm,t2
+            .copyArgument(argOutputDest, Buffer.CACHE2)
+            .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, ScriptAssembler.HashType.DoubleSHA256)
+            .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE1, 0, ScriptAssembler.base58Charset,
+                ScriptAssembler.zeroInherit)
+            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE1))
+            .getScript();
+        return addressScript;
+    }
+
+    public static String getZECScript(boolean isTestnet) {
+        ScriptRlpArray array = new ScriptRlpArray();
+        ScriptRlpData argReverseVersion = array.getRlpItemArgument();
+        ScriptRlpData argReverseGroupId = array.getRlpItemArgument();
+        ScriptRlpData argHashPrevouts = array.getRlpItemArgument();
+        ScriptRlpData argHashSequences = array.getRlpItemArgument();
+        ScriptRlpData argOutputAmount = array.getRlpItemArgument();
+        ScriptRlpData argOutputScriptType = array.getRlpItemArgument();
+        ScriptRlpData argOutputDest = array.getRlpItemArgument();
+
+        ScriptRlpData argHaveChange = array.getRlpItemArgument();
+        ScriptRlpData argChangeAmount = array.getRlpItemArgument();
+        ScriptRlpData argChangeScriptType = array.getRlpItemArgument();
+        ScriptRlpData argChangePath = array.getRlpItemArgument();
+
+        ScriptRlpData argLockTime = array.getRlpItemArgument();
+        ScriptRlpData argExpiryHeight = array.getRlpItemArgument();
+        ScriptRlpData argReverseHashType = array.getRlpItemArgument();
+
+        String addressScript = getAddressScript(isTestnet, argOutputScriptType, argOutputDest);
+
+        String script = new ScriptAssembler().setCoinType(0x00)
+            .copyArgument(argReverseVersion)
+            .copyArgument(argReverseGroupId)
+            .copyArgument(argHashPrevouts)
+            .copyArgument(argHashSequences)
+
+            .baseConvert(argOutputAmount, Buffer.CACHE1, 8, ScriptAssembler.binaryCharset, ScriptAssembler.littleEndian)
+            // switch redeemScript P2PKH=00,P2SH=01
+            .switchString(argOutputScriptType, Buffer.CACHE1, "1976A914,17A914")
+            .copyArgument(argOutputDest, Buffer.CACHE1)
+            .switchString(argOutputScriptType, Buffer.CACHE1, "88AC,87")
+            // if haveChange
+            .ifEqual(argHaveChange, "01",
+                new ScriptAssembler()
+                    .baseConvert(argChangeAmount, Buffer.CACHE1, 8, ScriptAssembler.binaryCharset,
+                        ScriptAssembler.littleEndian)
+                    .derivePublicKey(argChangePath, Buffer.CACHE2)
+                    .copyString("1976A914", Buffer.CACHE1)
+                    // if P2PKH
+                    .ifEqual(argChangeScriptType, "00",
+                        new ScriptAssembler()
+                            .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE1,
+                                ScriptAssembler.HashType.SHA256RipeMD160)
+                            .getScript(),
+                        "")
+                    .copyString("88AC", Buffer.CACHE1)
+                    .getScript(),
+                "")
+            .hash(ScriptData.getDataBufferAll(Buffer.CACHE1), Buffer.TRANSACTION, ScriptAssembler.HashType.DoubleSHA256)
+            .copyString("0000000000000000000000000000000000000000000000000000000000000000") // Hash JoinSplits
+            .copyString("0000000000000000000000000000000000000000000000000000000000000000") // Hash ShieldedSpends
+            .copyString("0000000000000000000000000000000000000000000000000000000000000000") // Hash ShieldedOutputs
+            .copyArgument(argLockTime)
+            .copyArgument(argExpiryHeight)
+            .copyString("0000000000000000") // Value Balance
+            .copyArgument(argReverseHashType)
+            .utxoDataPlaceholder()
+            .clearBuffer(Buffer.CACHE1)
+            .clearBuffer(Buffer.CACHE2)
+            .showMessage("ZEC")
+            .insertString(addressScript)
+            .showAmount(argOutputAmount, 8)
+            .showPressButton()
+            .setHeader(ScriptAssembler.HashType.DoubleSHA256, ScriptAssembler.SignType.ECDSA)
+            .getScript();
+        return script;
+    }
+
+    public static String ZECScriptSignature = Strings.padEnd("FA", 144, '0');
+
+}

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
@@ -509,11 +509,26 @@ public class ScriptAssembler {
      * @param data
      * @return
      */
+    @Deprecated
     public ScriptAssembler utxoDataPlaceholder(ScriptObjectAbstract data) {
         if (version.getVersionNum() < 7) {
             version = versionType.version07;
         }
         script += compose("C4", data, Buffer.TRANSACTION, 2, 0);
+        return this;
+    }
+
+    /**
+     * Send utxo data place holder length.
+     *
+     * @param data
+     * @return
+     */
+    public ScriptAssembler utxoDataPlaceholder() {
+        if (version.getVersionNum() < 7) {
+            version = versionType.version07;
+        }
+        script += compose("C4", null, Buffer.TRANSACTION, 2, 0);
         return this;
     }
 
@@ -630,6 +645,12 @@ public class ScriptAssembler {
             version = versionType.version09;
         }
         script += compose("5B", data, destinationBuf, 0, 0);
+        return this;
+    }
+
+    public ScriptAssembler advancedHash(ScriptRlpArray data, Buffer destinationBuf, AdvancedHashType hashType) {
+        int hashIndex = hashType.toInt();
+        script += compose("5C", data, destinationBuf, hashIndex & 0xf, hashIndex >>> 4);
         return this;
     }
 

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
@@ -49,6 +49,7 @@ public class ScriptAssembler {
     }
 
     public interface AlgorithmType {
+
         String toString();
     }
 
@@ -197,7 +198,7 @@ public class ScriptAssembler {
             argVar = String.format("%02d", path.length);
             argVar += Hex.encode(path);
         } else if (dataBuf instanceof ScriptRlpArray) {
-            firstParameter += "A"; // RLP should from ARGUMENT
+            firstParameter += "B";
             byte[] path = ((ScriptRlpArray) dataBuf).getPath();
             argVar = String.format("%02d", path.length);
             argVar += Hex.encode(path);
@@ -211,7 +212,7 @@ public class ScriptAssembler {
 
         if (null == destBuf) {
             firstParameter += "7"; // This parameter should be 0, but it would affect existing scripts, so it's
-                                   // kept as is
+            // kept as is
         } else {
             switch (destBuf) {
             case TRANSACTION:
@@ -347,14 +348,14 @@ public class ScriptAssembler {
     /**
      * Copy string to destination buffer with switch condition.
      *
-     * @param conditionData  One byte condition data, number only(
-     *                       "00","01","02"...). For example, if the condition data
-     *                       is "01", will copy the second(start from zero) string
-     *                       in the stringArray to destination buffer. If
-     *                       conditionData is greater the the size of stringArray or
-     *                       less zero will throw 0x6A0D error.
+     * @param conditionData One byte condition data, number only(
+     * "00","01","02"...). For example, if the condition data is "01", will copy
+     * the second(start from zero) string in the stringArray to destination
+     * buffer. If conditionData is greater the the size of stringArray or less
+     * zero will throw 0x6A0D error.
      * @param destinationBuf The destination buffer.
-     * @param stringArray    The string array concatenate with comma(ex. "A,B,C,D").
+     * @param stringArray The string array concatenate with comma(ex.
+     * "A,B,C,D").
      * @return
      */
     public ScriptAssembler switchString(ScriptObjectAbstract conditionData, Buffer destinationBuf, String stringArray) {
@@ -393,9 +394,8 @@ public class ScriptAssembler {
             return switchString(scriptTypeData, Buffer.TRANSACTION, "1976A914,17A914,160014,220020")
                 // switch redeemScript P2PKH=00,P2SH=01,P2WPKH=02,P2WSH=03
                 .insertString(content)
-                .switchString(scriptTypeData, Buffer.TRANSACTION, "88AC,87,[],[]"); // switch
-                                                                                                          // redeemScript
-                                                                                                          // end
+                // switch redeemScript end
+                .switchString(scriptTypeData, Buffer.TRANSACTION, "88AC,87,[],[]");
         case 79:
             return switchString(scriptTypeData, Buffer.TRANSACTION, "3F76A914,3DA914").insertString(content)
                 .switchString(scriptTypeData, Buffer.TRANSACTION, "88AC,87");
@@ -532,8 +532,8 @@ public class ScriptAssembler {
     }
 
     /**
-     * Check whether the data is in range of asc-ii code encode (0x20~0x7e, except
-     * 0x23(")) or not.
+     * Check whether the data is in range of asc-ii code encode (0x20~0x7e,
+     * except 0x23(")) or not.
      *
      * @param data
      * @return
@@ -544,9 +544,9 @@ public class ScriptAssembler {
     }
 
     /**
-     * Copy buffer data and put the output to transaction buffer. At the same time
-     * will check whether the data is in range of asc-ii code encode (0x20~0x7e,
-     * except 0x23(")) or not.
+     * Copy buffer data and put the output to transaction buffer. At the same
+     * time will check whether the data is in range of asc-ii code encode
+     * (0x20~0x7e, except 0x23(")) or not.
      *
      * @param data
      * @return
@@ -556,9 +556,9 @@ public class ScriptAssembler {
     }
 
     /**
-     * Copy buffer data and put the output to destination buffer. At the same time
-     * will check whether the data is in range of asc-ii code encode (0x20~0x7e,
-     * except 0x23(")) or not.
+     * Copy buffer data and put the output to destination buffer. At the same
+     * time will check whether the data is in range of asc-ii code encode
+     * (0x20~0x7e, except 0x23(")) or not.
      *
      * @param data
      * @param destinationBuf The destination buffer.
@@ -571,16 +571,15 @@ public class ScriptAssembler {
     /**
      * Convert the data encode and put the output to destination buffer.
      *
-     * @param data           The data should to encode.
+     * @param data The data should to encode.
      * @param destinationBuf The destination of the encoded data.
-     * @param outputLimit    The limit length of encoded result.
-     * @param charset        The name of the charset requested: "binaryCharset",
-     *                       "hexadecimalCharset", "bcdCharset", "decimalCharset",
-     *                       "binary32Charset", "base32BitcoinCashCharset",
-     *                       "base58Charset", "extentetCharset".
-     * @param baseConvertArg The number of the base-cenoding requested: leftJustify
-     *                       = 0x01, littleEndian = 0x02, zeroInherit = 0x04,
-     *                       bitLeftJustify8to5 = 0x08, inLittleEndian = 0x10.
+     * @param outputLimit The limit length of encoded result.
+     * @param charset The name of the charset requested: "binaryCharset",
+     * "hexadecimalCharset", "bcdCharset", "decimalCharset", "binary32Charset",
+     * "base32BitcoinCashCharset", "base58Charset", "extentetCharset".
+     * @param baseConvertArg The number of the base-cenoding requested:
+     * leftJustify = 0x01, littleEndian = 0x02, zeroInherit = 0x04,
+     * bitLeftJustify8to5 = 0x08, inLittleEndian = 0x10.
      * @return
      */
     public ScriptAssembler baseConvert(ScriptObjectAbstract data, Buffer destinationBuf, int outputLimit,
@@ -618,9 +617,9 @@ public class ScriptAssembler {
     /**
      * Hash data and put the output to destination buffer.
      *
-     * @param data           The input data.
+     * @param data The input data.
      * @param destinationBuf The destination buffer.
-     * @param hashType       The parameter is defined in enumeration class HashType
+     * @param hashType The parameter is defined in enumeration class HashType
      * @return
      */
     public ScriptAssembler hash(ScriptObjectAbstract data, Buffer destinationBuf, HashType hashType) {
@@ -630,12 +629,12 @@ public class ScriptAssembler {
     }
 
     /**
-     * Hash data and put the output to destination buffer. NOTE: todo implement with
-     * script rlp data
+     * Hash data and put the output to destination buffer. 
+     * NOTE: replaced by advancedHash
      *
-     * @param data           The input data.
+     * @param data The input data.
      * @param destinationBuf The destination buffer.
-     * @param hashType       The parameter is defined in enumeration class HashType
+     * @param hashType The parameter is defined in enumeration class HashType
      * @return
      */
     @Deprecated
@@ -647,16 +646,34 @@ public class ScriptAssembler {
         return this;
     }
 
+    /**
+     * Hash data and put the output to destination buffer
+     *
+     * @param data The input data should be rlp encoded. And the first item should be the data to hash, the second item should be the context to hash.
+     * @param destinationBuf The destination buffer.
+     * @param hashType The parameter is defined in enumeration class
+     * AdvancedHashType
+     * @return
+     */
     public ScriptAssembler advancedHash(ScriptRlpArray data, Buffer destinationBuf, AdvancedHashType hashType) {
         int hashIndex = hashType.toInt();
         script += compose("5C", data, destinationBuf, hashIndex & 0xf, hashIndex >>> 4);
         return this;
     }
 
+    public ScriptAssembler advancedHash(ScriptObjectAbstract data, ScriptObjectAbstract key, Buffer destinationBuf,
+        AdvancedHashType hashType) {
+        int hashIndex = hashType.toInt();
+        script += compose("5D", key, destinationBuf, hashIndex & 0xf, hashIndex >>> 4);
+        script += compose("5A", data, destinationBuf, hashIndex & 0xf, hashIndex >>> 4);
+        return this;
+    }
+
     /**
-     * Derive public key by derive path and put the output to destination buffer.
+     * Derive public key by derive path and put the output to destination
+     * buffer.
      *
-     * @param pathData       Derive path.
+     * @param pathData Derive path.
      * @param destinationBuf The destination buffer.
      * @return
      */
@@ -668,7 +685,7 @@ public class ScriptAssembler {
     /**
      * Compute Bech32 ploymod checksum and put the output to destination buffer.
      *
-     * @param data           The input data.
+     * @param data The input data.
      * @param destinationBuf The destination buffer.
      * @return
      */
@@ -681,9 +698,10 @@ public class ScriptAssembler {
     }
 
     /**
-     * Compute Bech3m2 ploymod checksum and put the output to destination buffer.
+     * Compute Bech3m2 ploymod checksum and put the output to destination
+     * buffer.
      *
-     * @param data           The input data.
+     * @param data The input data.
      * @param destinationBuf The destination buffer.
      * @return
      */
@@ -698,7 +716,7 @@ public class ScriptAssembler {
     /**
      * Compute BCH ploymod checksum and put the output to destination buffer.
      *
-     * @param data           The input data.
+     * @param data The input data.
      * @param destinationBuf The destination buffer.
      * @return
      */
@@ -760,9 +778,8 @@ public class ScriptAssembler {
      * Padding zero to the destination buffer.
      *
      * @param destinationBuf Destination buffer.
-     * @param base           The number of padding zero is the base minus the
-     *                       remainder of bufferInt divided by base(base -
-     *                       (bufferInt % base)).
+     * @param base The number of padding zero is the base minus the remainder of
+     * bufferInt divided by base(base - (bufferInt % base)).
      * @return
      */
     public ScriptAssembler paddingZero(Buffer destinationBuf, int base) {
@@ -784,9 +801,9 @@ public class ScriptAssembler {
      * If argData equals to expect, the the card execute the trueStatement,
      * otherwise execute the falseStatement.
      *
-     * @param argData        Requirement.
-     * @param expect         Analyzing conditions.
-     * @param trueStatement  The script wanna execute when the status is true.
+     * @param argData Requirement.
+     * @param expect Analyzing conditions.
+     * @param trueStatement The script wanna execute when the status is true.
      * @param falseStatement The script wanna execute when the status is false.
      * @return
      */
@@ -826,13 +843,13 @@ public class ScriptAssembler {
     }
 
     /**
-     * If the value of argData lies between min and max(min ≤ argData ≤ max) then
-     * run trueStatement; if not, please run falseStatement.
+     * If the value of argData lies between min and max(min ≤ argData ≤ max)
+     * then run trueStatement; if not, please run falseStatement.
      *
-     * @param argData        Requirement.
-     * @param min            The min value of the range.
-     * @param max            The max value of the range.
-     * @param trueStatement  The script wanna execute when the status is true.
+     * @param argData Requirement.
+     * @param min The min value of the range.
+     * @param max The max value of the range.
+     * @param trueStatement The script wanna execute when the status is true.
      * @param falseStatement The script wanna execute when the status is false.
      * @return
      */
@@ -857,14 +874,14 @@ public class ScriptAssembler {
     }
 
     /**
-     * Use CoolBitX public key to verify that the signature is valid or not. If the
-     * result is true, the the card execute the trueStatement, otherwise execute the
-     * falseStatement.
+     * Use CoolBitX public key to verify that the signature is valid or not. If
+     * the result is true, the the card execute the trueStatement, otherwise
+     * execute the falseStatement.
      *
-     * @param argData        Requirement.
-     * @param signData       The encoded ECDSA(CBKey) signature. Signing:
-     *                       SHA256(argData).
-     * @param trueStatement  The script wanna execute when the status is true.
+     * @param argData Requirement.
+     * @param signData The encoded ECDSA(CBKey) signature. Signing:
+     * SHA256(argData).
+     * @param trueStatement The script wanna execute when the status is true.
      * @param falseStatement The script wanna execute when the status is false.
      * @return
      */
@@ -939,7 +956,7 @@ public class ScriptAssembler {
     /**
      * Show transaction amount on card.
      *
-     * @param data    The transaction amount data.
+     * @param data The transaction amount data.
      * @param decimal The decimal in this transaction.
      * @return
      */
@@ -960,7 +977,7 @@ public class ScriptAssembler {
     /**
      * Protobuf decode data put the output to transaction buffer.
      *
-     * @param data     The input data.
+     * @param data The input data.
      * @param wireType
      * @return
      */
@@ -971,7 +988,7 @@ public class ScriptAssembler {
     /**
      * Protobuf decode data put the output to destination buffer.
      *
-     * @param data           The input data.
+     * @param data The input data.
      * @param destinationBuf The destination buffer.
      * @param wireType
      * @return
@@ -1023,7 +1040,8 @@ public class ScriptAssembler {
      * Encode data from the last position point in arrayPointer function with
      * specified encoding.
      *
-     * @param type 0: protobuf, 1: rlp, 2: message pack map, 3: message pack array
+     * @param type 0: protobuf, 1: rlp, 2: message pack map, 3: message pack
+     * array
      * @return
      */
     public ScriptAssembler arrayEnd(int type) {
@@ -1037,7 +1055,7 @@ public class ScriptAssembler {
     /**
      * Scale decode data and put the output to destination buffer.
      *
-     * @param data           The input data.
+     * @param data The input data.
      * @param destinationBuf The destination buffer.
      * @return
      */
@@ -1052,7 +1070,7 @@ public class ScriptAssembler {
     /**
      * Scale encode data and put the output to destination buffer.
      *
-     * @param data           The input data.
+     * @param data The input data.
      * @param destinationBuf The destination buffer.
      * @return
      */
@@ -1069,11 +1087,10 @@ public class ScriptAssembler {
     /**
      * Message pack encode data and put the output to destination buffer.
      *
-     * @param type           0: Int, 1: String, 2: Boolean
-     * @param data           The input data. When type equals to Int, data is
-     *                       Hexadecimal. Type equals to String, data is ascii code
-     *                       staing. Type equals to Boolean, 0x00 means false, 0x01
-     *                       means true.
+     * @param type 0: Int, 1: String, 2: Boolean
+     * @param data The input data. When type equals to Int, data is Hexadecimal.
+     * Type equals to String, data is ascii code staing. Type equals to Boolean,
+     * 0x00 means false, 0x01 means true.
      * @param destinationBuf The destination buffer.
      * @return
      */
@@ -1089,8 +1106,8 @@ public class ScriptAssembler {
      * Message pack string type encode data and put the output to destination
      * buffer.
      *
-     * @param data           The input data. Only support String, data is ascii code
-     *                       staing.
+     * @param data The input data. Only support String, data is ascii code
+     * staing.
      * @param destinationBuf The destination buffer.
      * @return
      */

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
@@ -48,10 +48,14 @@ public class ScriptAssembler {
         return script;
     }
 
-    public enum HashType {
+    public interface AlgorithmType {
+        String toString();
+    }
+
+    public enum HashType implements AlgorithmType {
         NONE("00"), SHA1("01"), SHA256("02"), SHA512("03"), SHA3256("04"), SHA3512("05"), Keccak256("06"),
         Keccak512("07"), RipeMD160("08"), SHA256RipeMD160("09"), CRC16("0A"), DoubleSHA256("0D"), Blake2b256("0E"),
-        Blake2b512("0F"), SHA512256("10"), Blake3256("11"), Blake2b256Mac("13"), Blake2b512Mac("14");
+        Blake2b512("0F"), SHA512256("10"), Blake3256("11");
 
         private final String hashLabel;
 
@@ -71,6 +75,35 @@ public class ScriptAssembler {
         public static HashType fromInt(int type) {
             String typeString = String.format("%02x", type);
             for (HashType hashType : HashType.values()) {
+                if (hashType.hashLabel.equals(typeString)) {
+                    return hashType;
+                }
+            }
+            return NONE;
+        }
+    }
+
+    public enum AdvancedHashType implements AlgorithmType {
+        NONE("00"), Blake2b256Mac("13"), Blake2b512Mac("14"), Blake2b256Personal("15"), Blake2b512Personal("16");
+
+        private final String hashLabel;
+
+        private AdvancedHashType(String hashLabel) {
+            this.hashLabel = hashLabel;
+        }
+
+        @Override
+        public String toString() {
+            return hashLabel;
+        }
+
+        public int toInt() {
+            return Integer.parseInt(hashLabel, 16);
+        }
+
+        public static AdvancedHashType fromInt(int type) {
+            String typeString = String.format("%02x", type);
+            for (AdvancedHashType hashType : AdvancedHashType.values()) {
                 if (hashType.hashLabel.equals(typeString)) {
                     return hashType;
                 }
@@ -124,7 +157,7 @@ public class ScriptAssembler {
         }
     }
 
-    public ScriptAssembler setHeader(HashType hash, SignType sign) {
+    public ScriptAssembler setHeader(AlgorithmType hash, SignType sign) {
         if (!argType.equals("01")) {
             script = "03" + version.versionLabel + hash + sign + script;
         } else {
@@ -349,7 +382,7 @@ public class ScriptAssembler {
      * @param content
      * @return
      */
-    // @Deprecated
+    @Deprecated
     public ScriptAssembler btcScript(ScriptObjectAbstract scriptTypeData, int supportType, String content) {
         switch (supportType) {
         case 2:
@@ -591,7 +624,8 @@ public class ScriptAssembler {
      * @param hashType       The parameter is defined in enumeration class HashType
      * @return
      */
-    public ScriptAssembler newHash(ScriptObjectAbstract data, Buffer destinationBuf, HashType hashType) {
+    @Deprecated
+    public ScriptAssembler newHash(ScriptObjectAbstract data, Buffer destinationBuf, AdvancedHashType hashType) {
         if (version.getVersionNum() < 9) {
             version = versionType.version09;
         }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
@@ -35,12 +35,12 @@ public class ScriptAssembler {
     private versionType version;
     private String script;
     private String firstParameter, secondParameter;
-    private String argType = "00";
+    private String reserveType = "00";
 
     public ScriptAssembler() {
         this.version = versionType.version00;
         this.script = "";
-        argType = "00";
+        reserveType = "00";
         clearParameter();
     }
 
@@ -158,10 +158,10 @@ public class ScriptAssembler {
     }
 
     public ScriptAssembler setHeader(AlgorithmType hash, SignType sign) {
-        if (!argType.equals("01")) {
+        if (!reserveType.equals("01")) {
             script = "03" + version.versionLabel + hash + sign + script;
         } else {
-            script = "05" + version.versionLabel + hash + sign + "00" + argType + script;
+            script = "05" + version.versionLabel + hash + sign + "00" + reserveType + script;
         }
         return this;
     }
@@ -192,14 +192,12 @@ public class ScriptAssembler {
             addIntParameter(dataBuf.getBufferParameter1());
             addIntParameter(dataBuf.getBufferParameter2());
         } else if (dataBuf instanceof ScriptRlpData) {
-            firstParameter += "A"; // RLP should from ARGUMENT
-            argType = "01";
+            firstParameter += "B";
             byte[] path = ((ScriptRlpData) dataBuf).getPath();
             argVar = String.format("%02d", path.length);
             argVar += Hex.encode(path);
         } else if (dataBuf instanceof ScriptRlpArray) {
             firstParameter += "A"; // RLP should from ARGUMENT
-            argType = "01";
             byte[] path = ((ScriptRlpArray) dataBuf).getPath();
             argVar = String.format("%02d", path.length);
             argVar += Hex.encode(path);
@@ -394,7 +392,8 @@ public class ScriptAssembler {
         case 4:
             return switchString(scriptTypeData, Buffer.TRANSACTION, "1976A914,17A914,160014,220020")
                 // switch redeemScript P2PKH=00,P2SH=01,P2WPKH=02,P2WSH=03
-                .insertString(content).switchString(scriptTypeData, Buffer.TRANSACTION, "88AC,87,[],[]"); // switch
+                .insertString(content)
+                .switchString(scriptTypeData, Buffer.TRANSACTION, "88AC,87,[],[]"); // switch
                                                                                                           // redeemScript
                                                                                                           // end
         case 79:
@@ -719,8 +718,8 @@ public class ScriptAssembler {
     public ScriptAssembler setBufferInt(ScriptObjectAbstract data, int min, int max) {
         String setB = compose("B5", data, null, 0, 0);
         script += new ScriptAssembler()
-            .ifRange(data, HexUtil.toHexString(min, 1), HexUtil.toHexString(max, 1), "", throwSEError).getScript()
-            + setB;
+            .ifRange(data, HexUtil.toHexString(min, 1), HexUtil.toHexString(max, 1), "", throwSEError)
+            .getScript() + setB;
         return this;
     }
 


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This pull request introduces support for Zcash (ZEC) transparent transactions and includes significant refactoring of the script generation utilities to accommodate advanced hashing algorithms.

#### Key Changes
- Added a new `ZcashScript.java` file to support Zcash transparent transactions, including address generation and transaction signing logic utilizing `Blake2b256Personal` hashing.
- Introduced `AlgorithmType` interface and `AdvancedHashType` enum in `ScriptAssembler.java` to support more complex hashing algorithms like `Blake2b256Personal` and `Blake2b512Personal`.
- Refactored `ScriptAssembler`'s `setHeader` and `compose` methods to use the new `AlgorithmType` and updated argument handling for RLP data.
- Updated `KasScript.java` to utilize the new `AdvancedHashType` for Blake2b256Mac hashing.
- Added `main` and `listAll` methods to `XrpScript.java` for script listing, and applied minor code formatting adjustments across multiple files.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 279 (46.3%)   |
| Churn       | 106 (17.6%)   |
| Refactor    | 217 (36.0%)   |
| Total Changes | 602         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>