### PR TITLE
feat(script): CW-27284 update script version to 11

### DIFF
--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -23,8 +23,9 @@ public class XrpScript {
     }
 
     public static void listAll() {
-        System.out.println("Xrp: \n" + getXRPScript() + "\n");
+        System.out.println("Xrp script: \n" + getXRPScript() + "\n");
         System.out.println("Xrp new script: \n" + getXRPNewScript() + "\n");
+        System.out.println("Xrp sign message script: \n" + getXRPMessageScript() + "\n");
         System.out.println("Xrp RLP: \n" + getXRPRlpArgumentScript() + "\n");
     }
 
@@ -145,6 +146,24 @@ public class XrpScript {
 
     public static String XRPNewScriptSignature = Strings.padStart(
         "3044022011a087b28a0011597df3e6b495d7601a972022ad7233fe3e1e98d10b00d0b3f9022020e3b9b6c2f2b44decc1b33388dc44b5dedf095a73e43914c4a1959f5a055ecb",
+        144, '0');
+
+    public static String getXRPMessageScript() {
+        ScriptArgumentComposer sac = new ScriptArgumentComposer();
+        ScriptData argMessage = sac.getArgumentAll();
+
+        String script = new ScriptAssembler().setCoinType(0x90)
+            .copyArgument(argMessage)
+            .showMessage("XRP")
+            .showWrap("MESSAGE", "")
+            .showPressButton()
+            .setHeader(HashType.SHA512, SignType.ECDSA)
+            .getScript();
+        return script;
+    }
+
+    public static String XRPMessageScriptSignature = Strings.padStart(
+        "304502203cb23566193592ff71e7a5bb347d97f2107e2cf1036cf435088a0f30bf78929d022100ed230715a43903adae1dd2b63fcb39259f827e7b528b193b51d4819e8eb230d9",
         144, '0');
 
     public static String getXRPRlpArgumentScript() {

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -83,19 +83,19 @@ public class XrpScript {
 
     public static String getXRPNewScript() {
         ScriptRlpArray array = new ScriptRlpArray();
-        ScriptRlpData argFlags = array.getRlpItemArgument();
-        ScriptRlpData argSequence = array.getRlpItemArgument();
-        ScriptRlpData argDestinationTag = array.getRlpItemArgument();
-        ScriptRlpData argLastLedgerSequence = array.getRlpItemArgument();
-        ScriptRlpData argAmount = array.getRlpItemArgument();
-        ScriptRlpData argFee = array.getRlpItemArgument();
-        ScriptRlpData argPublicKey = array.getRlpItemArgument();
-        ScriptRlpData argAccount = array.getRlpItemArgument();
-        ScriptRlpData argDest = array.getRlpItemArgument();
-        ScriptRlpArray argMemos = array.getRlpArrayArgument();
-        ScriptRlpData argMemoData = argMemos.getRlpItemArgument();
-        ScriptRlpData argMemoType = argMemos.getRlpItemArgument();
-        ScriptRlpData argMemoFormat = argMemos.getRlpItemArgument();
+        ScriptRlpData argFlags = array.getRlpItemArgument(); // 4 bytes or null
+        ScriptRlpData argSequence = array.getRlpItemArgument(); // 4 bytes
+        ScriptRlpData argDestinationTag = array.getRlpItemArgument(); // 4 bytes or null
+        ScriptRlpData argLastLedgerSequence = array.getRlpItemArgument(); // 4 bytes
+        ScriptRlpData argAmount = array.getRlpItemArgument(); // 7 bytes
+        ScriptRlpData argFee = array.getRlpItemArgument(); // 7 bytes
+        ScriptRlpData argPublicKey = array.getRlpItemArgument(); // 33 bytes
+        ScriptRlpData argAccount = array.getRlpItemArgument(); // 20 bytes
+        ScriptRlpData argDest = array.getRlpItemArgument(); // 20 bytes
+        ScriptRlpArray argMemos = array.getRlpArrayArgument(); // variable array of bytes or null
+        ScriptRlpData argMemoData = argMemos.getRlpItemArgument(); // variable bytes or null
+        ScriptRlpData argMemoType = argMemos.getRlpItemArgument(); // variable byte or null
+        ScriptRlpData argMemoFormat = argMemos.getRlpItemArgument(); // variable byte or null
 
         String script = new ScriptAssembler().setCoinType(0x90)
             .copyString("53545800")
@@ -120,8 +120,8 @@ public class XrpScript {
             .copyArgument(argDest)
             .isEmpty(argMemos, "", new ScriptAssembler().copyString("F9")
                 .copyString("EA")
-                .isEmpty(argMemoData, "", new ScriptAssembler().copyString("7C").copyArgument(argMemoData).getScript())
-                .isEmpty(argMemoType, "", new ScriptAssembler().copyString("7D").copyArgument(argMemoType).getScript())
+                .isEmpty(argMemoType, "", new ScriptAssembler().copyString("7C").copyArgument(argMemoType).getScript())
+                .isEmpty(argMemoData, "", new ScriptAssembler().copyString("7D").copyArgument(argMemoData).getScript())
                 .isEmpty(argMemoFormat, "",
                     new ScriptAssembler().copyString("7E").copyArgument(argMemoFormat).getScript())
                 .copyString("E1")

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -26,7 +26,6 @@ public class XrpScript {
         System.out.println("Xrp script: \n" + getXRPScript() + "\n");
         System.out.println("Xrp new script: \n" + getXRPNewScript() + "\n");
         System.out.println("Xrp sign message script: \n" + getXRPMessageScript() + "\n");
-        System.out.println("Xrp RLP: \n" + getXRPRlpArgumentScript() + "\n");
     }
 
     public static String getXRPScript() {
@@ -153,6 +152,7 @@ public class XrpScript {
         ScriptData argMessage = sac.getArgumentAll();
 
         String script = new ScriptAssembler().setCoinType(0x90)
+            .copyString("16585250205369676E6564204D6573736167653A0A") // \x16XRP Signed Message:\n
             .copyArgument(argMessage)
             .showMessage("XRP")
             .showWrap("MESSAGE", "")
@@ -163,56 +163,7 @@ public class XrpScript {
     }
 
     public static String XRPMessageScriptSignature = Strings.padStart(
-        "304502203cb23566193592ff71e7a5bb347d97f2107e2cf1036cf435088a0f30bf78929d022100ed230715a43903adae1dd2b63fcb39259f827e7b528b193b51d4819e8eb230d9",
+        "3045022100c506a4230844357bfb3ca1fe11c811302da05a7dc56de044dd149ce4f5471aa90220670efa881aaf65da22517348ca4ce4f1f5cbf3b793da377a050293b6ec13d1d4",
         144, '0');
-
-    public static String getXRPRlpArgumentScript() {
-        ScriptRlpArray array = new ScriptRlpArray();
-        ScriptRlpData argAccount = array.getRlpItemArgument();
-        ScriptRlpData argPublicKey = array.getRlpItemArgument();
-        ScriptRlpData argDest = array.getRlpItemArgument();
-        ScriptRlpData argAmount = array.getRlpItemArgument();
-        ScriptRlpData argFee = array.getRlpItemArgument();
-        ScriptRlpData argSequence = array.getRlpItemArgument();
-        ScriptRlpData argLastLedgerSequence = array.getRlpItemArgument();
-        ScriptRlpData argTag = array.getRlpItemArgument();
-        ScriptRlpData argFlags = array.getRlpItemArgument();
-
-        String script = new ScriptAssembler().setCoinType(0x90)
-            .copyString("5354580012000022")
-            .copyArgument(argFlags)
-            .copyString("24")
-            .copyArgument(argSequence)
-            .copyString("2E")
-            .copyArgument(argTag)
-            .copyString("201B")
-            .copyArgument(argLastLedgerSequence)
-            .copyString("6140")
-            .copyArgument(argAmount)
-            .copyString("6840")
-            .copyArgument(argFee)
-            .copyString("7321")
-            .copyArgument(argPublicKey)
-            .copyString("8114")
-            .copyArgument(argAccount)
-            .copyString("8314")
-            .copyArgument(argDest)
-            .showMessage("XRP")
-            .copyString("00", Buffer.CACHE2)
-            .copyArgument(argDest, Buffer.CACHE2)
-            .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
-            .copyString(HexUtil.toHexString("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
-                Buffer.CACHE1)
-            .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE2, 45, ScriptAssembler.cache1Charset,
-                ScriptAssembler.zeroInherit)
-            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53))
-            .showAmount(argAmount, 6)
-            .showPressButton()
-            .setHeader(HashType.SHA512, SignType.ECDSA)
-            .getScript();
-        return script;
-    }
-
-    public static String XRPRlpArgumentScriptSignature = Strings.padEnd("FA", 144, '0');
 
 }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -24,6 +24,7 @@ public class XrpScript {
 
     public static void listAll() {
         System.out.println("Xrp: \n" + getXRPScript() + "\n");
+        System.out.println("Xrp new script: \n" + getXRPNewScript() + "\n");
         System.out.println("Xrp RLP: \n" + getXRPRlpArgumentScript() + "\n");
     }
 
@@ -76,7 +77,75 @@ public class XrpScript {
         return script;
     }
 
-    public static String XRPScriptSignature = "0000304402206B2A707864EB98033BF83A80E8FDD7FCF903CC059ABC0E4FBB317040B6E9AD1D02203DCD2BDC4480B88DB0D9DC74948BAF6BD62203E90AE39990978999ABEAEABA63";
+    public static String XRPScriptSignature = Strings.padStart(
+        "304402206B2A707864EB98033BF83A80E8FDD7FCF903CC059ABC0E4FBB317040B6E9AD1D02203DCD2BDC4480B88DB0D9DC74948BAF6BD62203E90AE39990978999ABEAEABA63",
+        144, '0');
+
+    public static String getXRPNewScript() {
+        ScriptRlpArray array = new ScriptRlpArray();
+        ScriptRlpData argFlags = array.getRlpItemArgument();
+        ScriptRlpData argSequence = array.getRlpItemArgument();
+        ScriptRlpData argDestinationTag = array.getRlpItemArgument();
+        ScriptRlpData argLastLedgerSequence = array.getRlpItemArgument();
+        ScriptRlpData argAmount = array.getRlpItemArgument();
+        ScriptRlpData argFee = array.getRlpItemArgument();
+        ScriptRlpData argPublicKey = array.getRlpItemArgument();
+        ScriptRlpData argAccount = array.getRlpItemArgument();
+        ScriptRlpData argDest = array.getRlpItemArgument();
+        ScriptRlpArray argMemos = array.getRlpArrayArgument();
+        ScriptRlpData argMemoData = argMemos.getRlpItemArgument();
+        ScriptRlpData argMemoType = argMemos.getRlpItemArgument();
+        ScriptRlpData argMemoFormat = argMemos.getRlpItemArgument();
+
+        String script = new ScriptAssembler().setCoinType(0x90)
+            .copyString("53545800")
+            .copyString("12") // TransactionType
+            .copyString("0000")
+            .isEmpty(argFlags, "", new ScriptAssembler().copyString("22").copyArgument(argFlags).getScript()) // Flags
+            .copyString("24") // Sequence
+            .copyArgument(argSequence)
+            .isEmpty(argDestinationTag, "",
+                new ScriptAssembler().copyString("2E").copyArgument(argDestinationTag).getScript()) // DestinationTag
+            .copyString("201B") // LastLedgerSequence, although optional, is strongly recommended
+            .copyArgument(argLastLedgerSequence)
+            .copyString("6140") // Amount
+            .copyArgument(argAmount)
+            .copyString("6840") // Fee
+            .copyArgument(argFee)
+            .copyString("7321") // SigningPubKey
+            .copyArgument(argPublicKey)
+            .copyString("8114") // Account
+            .copyArgument(argAccount)
+            .copyString("8314") // Destination
+            .copyArgument(argDest)
+            .isEmpty(argMemos, "", new ScriptAssembler().copyString("F9")
+                .copyString("EA")
+                .isEmpty(argMemoData, "", new ScriptAssembler().copyString("7C").copyArgument(argMemoData).getScript())
+                .isEmpty(argMemoType, "", new ScriptAssembler().copyString("7D").copyArgument(argMemoType).getScript())
+                .isEmpty(argMemoFormat, "",
+                    new ScriptAssembler().copyString("7E").copyArgument(argMemoFormat).getScript())
+                .copyString("E1")
+                .copyString("F1")
+                .getScript())
+            .showMessage("XRP")
+            .copyString("00", Buffer.CACHE2)
+            .copyArgument(argDest, Buffer.CACHE2)
+            .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
+            .copyString(HexUtil.toHexString("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
+                Buffer.CACHE1)
+            .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE2, 45, ScriptAssembler.cache1Charset,
+                ScriptAssembler.zeroInherit)
+            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53))
+            .showAmount(argAmount, 6)
+            .showPressButton()
+            .setHeader(HashType.SHA512, SignType.ECDSA)
+            .getScript();
+        return script;
+    }
+
+    public static String XRPNewScriptSignature = Strings.padStart(
+        "304402207c10ec80d90b59e09f586c1ac76b0b7aba8d9bfc2c554ce3d9430b5590a5a1530220719885ad5cc9fde206739b20744b800d0b215af302f8a820f5b4ac307f9d08c8",
+        144, '0');
 
     public static String getXRPRlpArgumentScript() {
         ScriptRlpArray array = new ScriptRlpArray();

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -93,8 +93,8 @@ public class XrpScript {
         ScriptRlpData argAccount = array.getRlpItemArgument(); // 20 bytes
         ScriptRlpData argDest = array.getRlpItemArgument(); // 20 bytes
         ScriptRlpArray argMemos = array.getRlpArrayArgument(); // variable array of bytes or null
-        ScriptRlpData argMemoData = argMemos.getRlpItemArgument(); // variable bytes or null
         ScriptRlpData argMemoType = argMemos.getRlpItemArgument(); // variable byte or null
+        ScriptRlpData argMemoData = argMemos.getRlpItemArgument(); // variable bytes or null
         ScriptRlpData argMemoFormat = argMemos.getRlpItemArgument(); // variable byte or null
 
         String script = new ScriptAssembler().setCoinType(0x90)
@@ -144,7 +144,7 @@ public class XrpScript {
     }
 
     public static String XRPNewScriptSignature = Strings.padStart(
-        "304402207c10ec80d90b59e09f586c1ac76b0b7aba8d9bfc2c554ce3d9430b5590a5a1530220719885ad5cc9fde206739b20744b800d0b215af302f8a820f5b4ac307f9d08c8",
+        "3044022011a087b28a0011597df3e6b495d7601a972022ad7233fe3e1e98d10b00d0b3f9022020e3b9b6c2f2b44decc1b33388dc44b5dedf095a73e43914c4a1959f5a055ecb",
         144, '0');
 
     public static String getXRPRlpArgumentScript() {

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/ZcashScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/ZcashScript.java
@@ -106,6 +106,6 @@ public class ZcashScript {
         return script;
     }
 
-    public static String ZECScriptSignature = Strings.padStart("3046022100a3204ca844ac7f31333226607b1c86a71940850ef75d4cb7ad25b4fd49cef0ba022100d6b6d7fd5aec8e77a837ec70a7a7419b343a49b0dfa6263c8b6ad196cc32e90d", 144, '0');
+    public static String ZECScriptSignature = Strings.padStart("3046022100eebe7b79978d11b265ceb3977a683df311d7d3a4844fc513a611d8ea20fb6d42022100ea45cb25c9aa448d693ec06334ee47a90f5dfdf84e868198cf957754c4547213", 144, '0');
 
 }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
@@ -139,7 +139,8 @@ public class ScriptAssembler {
 
     public static enum versionType {
         version00(0, "00"), version02(2, "02"), version03(3, "03"), version04(4, "04"), version05(5, "05"),
-        version06(6, "06"), version07(7, "07"), version08(8, "08"), version09(9, "09");
+        version06(6, "06"), version07(7, "07"), version08(8, "08"), version09(9, "09"), version10(10, "0A"),
+        version11(11, "0B");
 
         private final int versionNum;
         private final String versionLabel;
@@ -663,6 +664,9 @@ public class ScriptAssembler {
 
     public ScriptAssembler advancedHash(ScriptObjectAbstract data, ScriptObjectAbstract key, Buffer destinationBuf,
         AdvancedHashType hashType) {
+        if (version.getVersionNum() < 10) {
+            version = versionType.version10;
+        }
         int hashIndex = hashType.toInt();
         script += compose("5D", key, destinationBuf, hashIndex & 0xf, hashIndex >>> 4);
         script += compose("5A", data, destinationBuf, hashIndex & 0xf, hashIndex >>> 4);
@@ -831,10 +835,16 @@ public class ScriptAssembler {
         return this;
     }
 
-    public ScriptAssembler isEmpty(ScriptObjectAbstract argData, String trueStatement, String falseStatement) {
+    public ScriptAssembler isEmpty(ScriptInterface argData, String trueStatement, String falseStatement) {
         if (version.getVersionNum() < 6) {
             version = versionType.version06;
         }
+        if (argData instanceof ScriptRlpArray) {
+            if (version.getVersionNum() < 11) {
+                version = versionType.version11;
+            }
+        }
+
         if (!falseStatement.equals("")) {
             trueStatement += skip(falseStatement);
         }
@@ -1094,7 +1104,7 @@ public class ScriptAssembler {
      * @param destinationBuf The destination buffer.
      * @return
      */
-    public ScriptAssembler messagePack(int type, ScriptInterface data, Buffer destinationBuf) {
+    public ScriptAssembler messagePack(int type, ScriptObjectAbstract data, Buffer destinationBuf) {
         if (version.getVersionNum() < 6) {
             version = versionType.version06;
         }


### PR DESCRIPTION
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR introduces significant enhancements to XRP scripting capabilities, including new transaction and message signing scripts, and updates the core script assembler to support new script versions (10 and 11). These changes aim to provide more flexible and robust XRP transaction construction and message signing.

#### Key Changes
- Added `getXRPNewScript()` for advanced XRP transaction construction, supporting optional fields like memos, and `getXRPMessageScript()` for signing arbitrary XRP messages.
- Refactored and renamed the existing XRP RLP argument script to `getXRPNewScript()`, incorporating more detailed argument handling.
- Updated `ScriptAssembler` to include `version10` and `version11`, with logic to automatically bump the script version when using features like `advancedHash` or `isEmpty` with `ScriptRlpArray`.
- Updated the `XRPScriptSignature`, `XRPNewScriptSignature`, `XRPMessageScriptSignature`, and `ZECScriptSignature` values.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 49 (62.8%)    |
| Rework      | 29 (37.2%)    |
| Total Changes | 78            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>