### PR TITLE
[CW-27899] feat(XRP): support RLUSD

### DIFF
--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -28,6 +28,8 @@ public class XrpScript {
         System.out.println("XRP sign message script: \n" + getXRPMessageScript() + "\n");
         System.out.println("XRP IOU RLUSD trust set script: \n" + getXRPRLUSDTrustSetScript() + "\n");
         System.out.println("XRP IOU trust set script: \n" + getXRPTrustSetScript() + "\n");
+        System.out.println("XRP IOU RLUSD tx script: \n" + getXRPIOURLUSDScript() + "\n");
+        System.out.println("XRP IOU tx script: \n" + getXRPIOUScript() + "\n");
     }
 
     public static String getXRPScript() {
@@ -275,59 +277,185 @@ public class XrpScript {
         "3046022100a13acf6e4e0be56b54a11ff62988c51cec49b8fa2fcf27fd81ab705f0f26855c022100e5f04deaaa0e431447f4defe11b15f24df7a95266efb55956029b07491d2da71",
         144, '0');
 
-    // public static String getXRPTrustSetScript() {
-    //     ScriptArgumentComposer sac = new ScriptArgumentComposer();
-    //     ScriptData argSequence = sac.getArgument(4);
-    //     ScriptData argLastLedgerSequence = sac.getArgument(4);
-    //     ScriptData argLimitAmount = sac.getArgument(8);
-    //     ScriptData argPadding = sac.getArgument(1);
-    //     ScriptData argFee = sac.getArgument(7);
-    //     ScriptData argPublicKey = sac.getArgument(33);
-    //     ScriptData argAccount = sac.getArgument(20);
-    //     // IOU Info
-    //     ScriptData argTokenInfo = sac.getArgumentUnion(0, 41);
-    //     ScriptData argNameLength = sac.getArgument(1);
-    //     ScriptData argName = sac.getArgumentVariableLength(20);
-    //     ScriptData argIssuerAccount = sac.getArgument(20);
-    //     ScriptData argTokenSign = sac.getArgument(72);
+    public static String getXRPIOURLUSDScript() {
+        ScriptRlpArray array = new ScriptRlpArray();
+        ScriptRlpData argFlags = array.getRlpItemArgument(); // 4 bytes or null
+        ScriptRlpData argSequence = array.getRlpItemArgument(); // 4 bytes
+        ScriptRlpData argDestinationTag = array.getRlpItemArgument(); // 4 bytes or null
+        ScriptRlpData argLastLedgerSequence = array.getRlpItemArgument(); // 4 bytes
+        ScriptRlpData argAmount = array.getRlpItemArgument(); // 54 bits data put in 54 bytes array
+        ScriptRlpData argDeciaml = array.getRlpItemArgument(); // 1 byte
+        ScriptRlpData argFee = array.getRlpItemArgument(); // 7 bytes
+        ScriptRlpData argPublicKey = array.getRlpItemArgument(); // 33 bytes
+        ScriptRlpData argAccount = array.getRlpItemArgument(); // 20 bytes
+        ScriptRlpData argDest = array.getRlpItemArgument(); // 20 bytes
+        ScriptRlpArray argMemos = array.getRlpArrayArgument(); // variable array of bytes or null
+        ScriptRlpData argMemoType = argMemos.getRlpItemArgument(); // variable byte or null
+        ScriptRlpData argMemoData = argMemos.getRlpItemArgument(); // variable bytes or null
+        ScriptRlpData argMemoFormat = argMemos.getRlpItemArgument(); // variable byte or null
+        // IOU Info
+        ScriptRlpData argTokenInfo = array.getRlpItemArgument(); // 48 bytes[nameLength(1B)][name(padding zero)(7B)][tokenCode(20B)][issuerAccount(20B)]
 
-    //     String script = new ScriptAssembler().setCoinType(0x90)
-    //         .copyString("53545800")
-    //         .copyString("120014")
-    //         .copyString("24")
-    //         .copyArgument(argSequence)
-    //         .copyString("201B")
-    //         .copyArgument(argLastLedgerSequence)
-    //         .ifSigned(argTokenInfo, argTokenSign, "", ScriptAssembler.throwSEError)
-    //         .copyString("63")// [value][currency][issuer AccountID]
-    //         .copyArgument(argLimitAmount)
-    //         .setBufferIntFromDataLength(argIssuerAccount)
-    //         .copyArgument(argName)
-    //         .copyArgument(argIssuerAccount)
-    //         .copyString("6840")
-    //         .copyArgument(argFee)
-    //         .copyString("7321")
-    //         .copyArgument(argPublicKey)
-    //         .copyString("8114")
-    //         .copyArgument(argAccount)
-    //         .showMessage("XRP")
-    //         .showMessage("TRUST")
-    //         .setBufferInt(argNameLength, 1, 7)
-    //         .copyArgument(argName, Buffer.CACHE1)
-    //         .showMessage(ScriptData.getDataBufferAll(Buffer.CACHE1))
-    //         .clearBuffer(Buffer.CACHE1)
-    //         .copyString("00", Buffer.CACHE2)
-    //         .copyArgument(argIssuerAccount, Buffer.CACHE2)
-    //         .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
-    //         .copyString(HexUtil.toHexString("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
-    //             Buffer.CACHE1)
-    //         .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE2, 45, ScriptAssembler.cache1Charset,
-    //             ScriptAssembler.zeroInherit)
-    //         .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53))
-    //         .showPressButton()
-    //         .setHeader(HashType.SHA512, SignType.ECDSA)
-    //         .getScript();
-    //     return script;
-    // }
+        String script = new ScriptAssembler().setCoinType(0x90)
+            .copyString("53545800")
+            .copyString("12") // TransactionType
+            .copyString("0000")
+            .isEmpty(argFlags, "", new ScriptAssembler().copyString("22").copyArgument(argFlags).getScript()) // Flags
+            .copyString("24") // Sequence
+            .copyArgument(argSequence)
+            .isEmpty(argDestinationTag, "", // DestinationTag
+                new ScriptAssembler().copyString("2E").copyArgument(argDestinationTag).getScript())
+            .copyString("201B") // LastLedgerSequence, although optional, is strongly recommended
+            .copyArgument(argLastLedgerSequence)
+            .copyString("61") // Amount
+            .copyString("0101", Buffer.CACHE2)
+            .ifRange(argDeciaml, "08", "16", new ScriptAssembler().switchString(argDeciaml, Buffer.CACHE2,
+                "[],[],[],[],[],[],[],[],0001000101000001,0001000101000000,0001000100010101,0001000100010100,0001000100010001,0001000100010000,0001000100000101,0001000100000100,0001000100000001,0001000100000000,0001000001010101,0001000001010100,0001000001010001,0001000001010000,0001000001000101")
+                .getScript(), ScriptAssembler.throwSEError)
+            .copyArgument(argAmount, Buffer.CACHE2)
+            .bitToByte(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE1)
+            .clearBuffer(Buffer.CACHE2)
+            .copyArgument(argTokenInfo, Buffer.CACHE2)
+            .copyArgument(ScriptData.getBuffer(Buffer.CACHE2, 8, 40), Buffer.CACHE1)
+            .copyArgument(ScriptData.getDataBufferAll(Buffer.CACHE1))
+            .copyString("6840") // Fee
+            .copyArgument(argFee)
+            .copyString("69") // SendMax
+            .copyArgument(ScriptData.getDataBufferAll(Buffer.CACHE1))
+            .copyString("7321") // SigningPubKey
+            .copyArgument(argPublicKey)
+            .copyString("8114") // Account
+            .copyArgument(argAccount)
+            .copyString("8314") // Destination
+            .copyArgument(argDest)
+            .isEmpty(argMemos, "", new ScriptAssembler().copyString("F9")
+                .copyString("EA")
+                .isEmpty(argMemoType, "", new ScriptAssembler().copyString("7C").copyArgument(argMemoType).getScript())
+                .isEmpty(argMemoData, "", new ScriptAssembler().copyString("7D").copyArgument(argMemoData).getScript())
+                .isEmpty(argMemoFormat, "",
+                    new ScriptAssembler().copyString("7E").copyArgument(argMemoFormat).getScript())
+                .copyString("E1")
+                .copyString("F1")
+                .getScript())
+            .showMessage("XRP")
+            .showMessage("RLUSD")
+            .clearBuffer(Buffer.CACHE2)
+            .copyString("00", Buffer.CACHE2)
+            .copyArgument(argDest, Buffer.CACHE2)
+            .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
+            .clearBuffer(Buffer.CACHE1)
+            .copyString(HexUtil.toHexString("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
+                Buffer.CACHE1)
+            .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE2, 45, ScriptAssembler.cache1Charset,
+                ScriptAssembler.zeroInherit)
+            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53))
+            .clearBuffer(Buffer.CACHE1)
+            .clearBuffer(Buffer.CACHE2)
+            .copyString("0000", Buffer.CACHE1)
+            .copyArgument(argAmount, Buffer.CACHE1)
+            .bitToByte(ScriptData.getDataBufferAll(Buffer.CACHE1), Buffer.CACHE2)
+            .setBufferInt(argDeciaml, 8, 22)
+            .showAmount(ScriptData.getDataBufferAll(Buffer.CACHE2), ScriptData.bufInt)
+            .showPressButton()
+            .setHeader(HashType.SHA512, SignType.ECDSA)
+            .getScript();
+        return script;
+    }
+
+    public static String XRPIOURLUSDScriptSignature = Strings.padStart(
+        "304502206313724dbc74d985c680c1da43a089528be296a11f52783befd047b228e71108022100cf162503867a0a2f9ec0e58714af1db614c426cff24e6f45854c5a7ce8cec0de",
+        144, '0');
+
+    public static String getXRPIOUScript() {
+        ScriptRlpArray array = new ScriptRlpArray();
+        ScriptRlpData argFlags = array.getRlpItemArgument(); // 4 bytes or null
+        ScriptRlpData argSequence = array.getRlpItemArgument(); // 4 bytes
+        ScriptRlpData argDestinationTag = array.getRlpItemArgument(); // 4 bytes or null
+        ScriptRlpData argLastLedgerSequence = array.getRlpItemArgument(); // 4 bytes
+        ScriptRlpData argAmount = array.getRlpItemArgument(); // 54 bits data put in 54 bytes array
+        ScriptRlpData argDeciaml = array.getRlpItemArgument(); // 1 byte
+        ScriptRlpData argFee = array.getRlpItemArgument(); // 7 bytes
+        ScriptRlpData argPublicKey = array.getRlpItemArgument(); // 33 bytes
+        ScriptRlpData argAccount = array.getRlpItemArgument(); // 20 bytes
+        ScriptRlpData argDest = array.getRlpItemArgument(); // 20 bytes
+        ScriptRlpArray argMemos = array.getRlpArrayArgument(); // variable array of bytes or null
+        ScriptRlpData argMemoType = argMemos.getRlpItemArgument(); // variable byte or null
+        ScriptRlpData argMemoData = argMemos.getRlpItemArgument(); // variable bytes or null
+        ScriptRlpData argMemoFormat = argMemos.getRlpItemArgument(); // variable byte or null
+        // IOU Info
+        ScriptRlpData argTokenInfo = array.getRlpItemArgument(); // 48 bytes[nameLength(1B)][name(padding zero)(7B)][tokenCode(20B)][issuerAccount(20B)]
+
+        String script = new ScriptAssembler().setCoinType(0x90)
+            .copyString("53545800")
+            .copyString("12") // TransactionType
+            .copyString("0000")
+            .isEmpty(argFlags, "", new ScriptAssembler().copyString("22").copyArgument(argFlags).getScript()) // Flags
+            .copyString("24") // Sequence
+            .copyArgument(argSequence)
+            .isEmpty(argDestinationTag, "", // DestinationTag
+                new ScriptAssembler().copyString("2E").copyArgument(argDestinationTag).getScript())
+            .copyString("201B") // LastLedgerSequence, although optional, is strongly recommended
+            .copyArgument(argLastLedgerSequence)
+            .copyString("61") // Amount
+            .copyString("0101", Buffer.CACHE2)
+            .ifRange(argDeciaml, "08", "16", new ScriptAssembler().switchString(argDeciaml, Buffer.CACHE2,
+                "[],[],[],[],[],[],[],[],0001000101000001,0001000101000000,0001000100010101,0001000100010100,0001000100010001,0001000100010000,0001000100000101,0001000100000100,0001000100000001,0001000100000000,0001000001010101,0001000001010100,0001000001010001,0001000001010000,0001000001000101")
+                .getScript(), ScriptAssembler.throwSEError)
+            .copyArgument(argAmount, Buffer.CACHE2)
+            .bitToByte(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE1)
+            .clearBuffer(Buffer.CACHE2)
+            .copyArgument(argTokenInfo, Buffer.CACHE2)
+            .copyArgument(ScriptData.getBuffer(Buffer.CACHE2, 8, 40), Buffer.CACHE1)
+            .copyArgument(ScriptData.getDataBufferAll(Buffer.CACHE1))
+            .copyString("6840") // Fee
+            .copyArgument(argFee)
+            .copyString("69") // SendMax
+            .copyArgument(ScriptData.getDataBufferAll(Buffer.CACHE1))
+            .copyString("7321") // SigningPubKey
+            .copyArgument(argPublicKey)
+            .copyString("8114") // Account
+            .copyArgument(argAccount)
+            .copyString("8314") // Destination
+            .copyArgument(argDest)
+            .isEmpty(argMemos, "", new ScriptAssembler().copyString("F9")
+                .copyString("EA")
+                .isEmpty(argMemoType, "", new ScriptAssembler().copyString("7C").copyArgument(argMemoType).getScript())
+                .isEmpty(argMemoData, "", new ScriptAssembler().copyString("7D").copyArgument(argMemoData).getScript())
+                .isEmpty(argMemoFormat, "",
+                    new ScriptAssembler().copyString("7E").copyArgument(argMemoFormat).getScript())
+                .copyString("E1")
+                .copyString("F1")
+                .getScript())
+            .showMessage("XRP")
+            .copyString(HexUtil.toHexString("@"), Buffer.CACHE2)
+            .setBufferInt(ScriptData.getBuffer(Buffer.CACHE2, 0, 1), 1, 7)
+            .copyArgument(ScriptData.getBuffer(Buffer.CACHE2, 1, ScriptData.bufInt), Buffer.CACHE2)
+            .showMessage(ScriptData.getDataBufferAll(Buffer.CACHE2, 48))
+            .clearBuffer(Buffer.CACHE2)
+            .copyString("00", Buffer.CACHE2)
+            .copyArgument(argDest, Buffer.CACHE2)
+            .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
+            .clearBuffer(Buffer.CACHE1)
+            .copyString(HexUtil.toHexString("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
+                Buffer.CACHE1)
+            .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE2, 45, ScriptAssembler.cache1Charset,
+                ScriptAssembler.zeroInherit)
+            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53))
+            .clearBuffer(Buffer.CACHE1)
+            .clearBuffer(Buffer.CACHE2)
+            .copyString("0000", Buffer.CACHE1)
+            .copyArgument(argAmount, Buffer.CACHE1)
+            .bitToByte(ScriptData.getDataBufferAll(Buffer.CACHE1), Buffer.CACHE2)
+            .setBufferInt(argDeciaml, 8, 22)
+            .showAmount(ScriptData.getDataBufferAll(Buffer.CACHE2), ScriptData.bufInt)
+            .showPressButton()
+            .setHeader(HashType.SHA512, SignType.ECDSA)
+            .getScript();
+        return script;
+    }
+
+    public static String XRPIOUScriptSignature = Strings.padStart(
+        "30450220362cde66c17cac9ccc34594297727550db246ce42d422b2e88b6da1485821489022100f8a4d4bbedd7121afdb87487475ec1692f6fd3c42d37df804d5933dbfd009017",
+        144, '0');
 
 }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -318,8 +318,6 @@ public class XrpScript {
             .copyArgument(ScriptData.getDataBufferAll(Buffer.CACHE1))
             .copyString("6840") // Fee
             .copyArgument(argFee)
-            .copyString("69") // SendMax
-            .copyArgument(ScriptData.getDataBufferAll(Buffer.CACHE1))
             .copyString("7321") // SigningPubKey
             .copyArgument(argPublicKey)
             .copyString("8114") // Account
@@ -360,7 +358,7 @@ public class XrpScript {
     }
 
     public static String XRPIOURLUSDScriptSignature = Strings.padStart(
-        "3045022100a27f3abf1a1563f61349ae2d5127fb625167ca63e7e5b99413f234a99b5b9bf002206e24954c586017b5d941b38e64f0d49ec73b71e23f87dd30bc05c5f658cd0528",
+        "3045022100e64ef2d9bf63dd025b91b5ae28b3b0ddc2d0f0fcb9be99c9abe7f332ad15f17a02200cc1d3a049190e8a31385c586f78efefd6c5b6d21cd02ba3497ec6154518710b",
         144, '0');
 
     public static String getXRPIOUScript() {
@@ -406,8 +404,6 @@ public class XrpScript {
             .copyArgument(ScriptData.getDataBufferAll(Buffer.CACHE1))
             .copyString("6840") // Fee
             .copyArgument(argFee)
-            .copyString("69") // SendMax
-            .copyArgument(ScriptData.getDataBufferAll(Buffer.CACHE1))
             .copyString("7321") // SigningPubKey
             .copyArgument(argPublicKey)
             .copyString("8114") // Account
@@ -452,7 +448,7 @@ public class XrpScript {
     }
 
     public static String XRPIOUScriptSignature = Strings.padStart(
-        "30450220362cde66c17cac9ccc34594297727550db246ce42d422b2e88b6da1485821489022100f8a4d4bbedd7121afdb87487475ec1692f6fd3c42d37df804d5933dbfd009017",
+        "30460221009d110b11b2f090b9b3048a4f11c6d428cf778fbfe9a4484860ee95d914ab63a5022100e1e2989a647d5d6740035cc70c6abfaff3c204fb88cd1e796db444a22ed3c052",
         144, '0');
 
 }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -23,9 +23,10 @@ public class XrpScript {
     }
 
     public static void listAll() {
-        System.out.println("Xrp script: \n" + getXRPScript() + "\n");
-        System.out.println("Xrp new script: \n" + getXRPNewScript() + "\n");
-        System.out.println("Xrp sign message script: \n" + getXRPMessageScript() + "\n");
+        System.out.println("XRP script: \n" + getXRPScript() + "\n");
+        System.out.println("XRP new script: \n" + getXRPNewScript() + "\n");
+        System.out.println("XRP sign message script: \n" + getXRPMessageScript() + "\n");
+        System.out.println("XRP IOU trust set script: \n" + getXRPTrustSetScript() + "\n");
     }
 
     public static String getXRPScript() {
@@ -166,4 +167,62 @@ public class XrpScript {
         "3045022100c506a4230844357bfb3ca1fe11c811302da05a7dc56de044dd149ce4f5471aa90220670efa881aaf65da22517348ca4ce4f1f5cbf3b793da377a050293b6ec13d1d4",
         144, '0');
 
+    public static String getXRPTrustSetScript() {
+        ScriptArgumentComposer sac = new ScriptArgumentComposer();
+        ScriptData argSequence = sac.getArgument(4);
+        ScriptData argLastLedgerSequence = sac.getArgument(4);
+        ScriptData argLimitAmount = sac.getArgument(8);
+        ScriptData argPadding = sac.getArgument(1);
+        ScriptData argFee = sac.getArgument(7);
+        ScriptData argPublicKey = sac.getArgument(33);
+        ScriptData argAccount = sac.getArgument(20);
+        // IOU Info
+        ScriptData argTokenInfo = sac.getArgumentUnion(0, 41);
+        ScriptData argNameLength = sac.getArgument(1);
+        ScriptData argName = sac.getArgumentVariableLength(20);
+        ScriptData argIssuerAccount = sac.getArgument(20);
+        ScriptData argTokenSign = sac.getArgument(72);
+
+        String script = new ScriptAssembler().setCoinType(0x90)
+            .copyString("53545800")
+            .copyString("120014")
+            .copyString("24")
+            .copyArgument(argSequence)
+            .copyString("201B")
+            .copyArgument(argLastLedgerSequence)
+            .ifSigned(argTokenInfo, argTokenSign, "", ScriptAssembler.throwSEError)
+            .copyString("63")// [value][currency][issuer AccountID]
+            .copyArgument(argLimitAmount)
+            .setBufferIntFromDataLength(argIssuerAccount)
+            .copyArgument(argName)
+            .copyArgument(argIssuerAccount)
+            .copyString("6840")
+            .copyArgument(argFee)
+            .copyString("7321")
+            .copyArgument(argPublicKey)
+            .copyString("8114")
+            .copyArgument(argAccount)
+            .showMessage("XRP")
+            .showMessage("TRUST")
+            .setBufferInt(argNameLength, 1, 7)
+            .copyArgument(argName, Buffer.CACHE1)
+            .showMessage(ScriptData.getDataBufferAll(Buffer.CACHE1))
+            .clearBuffer(Buffer.CACHE1)
+            .copyString("00", Buffer.CACHE2)
+            .copyArgument(argIssuerAccount, Buffer.CACHE2)
+            .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
+            .copyString(HexUtil.toHexString("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
+                Buffer.CACHE1)
+            .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE2, 45, ScriptAssembler.cache1Charset,
+                ScriptAssembler.zeroInherit)
+            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53))
+            .showPressButton()
+            .setHeader(HashType.SHA512, SignType.ECDSA)
+            .getScript();
+        return script;
+    }
+
+    public static String XRPTrustSetScriptSignature = Strings.padStart(
+        "3045022100b1986907b0895be91ae1b9d3318f6bd62b130d55dc12d6298fd15fda7271426502202666797aa929d8c519abb9a8c34697c79fb0f344c1f962fce5a12a7a527ffe35",
+        144, '0');
 }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -26,6 +26,7 @@ public class XrpScript {
         System.out.println("XRP script: \n" + getXRPScript() + "\n");
         System.out.println("XRP new script: \n" + getXRPNewScript() + "\n");
         System.out.println("XRP sign message script: \n" + getXRPMessageScript() + "\n");
+        System.out.println("XRP IOU RLUSD trust set script: \n" + getXRPRLUSDTrustSetScript() + "\n");
         System.out.println("XRP IOU trust set script: \n" + getXRPTrustSetScript() + "\n");
     }
 
@@ -167,52 +168,100 @@ public class XrpScript {
         "3045022100c506a4230844357bfb3ca1fe11c811302da05a7dc56de044dd149ce4f5471aa90220670efa881aaf65da22517348ca4ce4f1f5cbf3b793da377a050293b6ec13d1d4",
         144, '0');
 
-    public static String getXRPTrustSetScript() {
-        ScriptArgumentComposer sac = new ScriptArgumentComposer();
-        ScriptData argSequence = sac.getArgument(4);
-        ScriptData argLastLedgerSequence = sac.getArgument(4);
-        ScriptData argLimitAmount = sac.getArgument(8);
-        ScriptData argPadding = sac.getArgument(1);
-        ScriptData argFee = sac.getArgument(7);
-        ScriptData argPublicKey = sac.getArgument(33);
-        ScriptData argAccount = sac.getArgument(20);
-        // IOU Info
-        ScriptData argTokenInfo = sac.getArgumentUnion(0, 41);
-        ScriptData argNameLength = sac.getArgument(1);
-        ScriptData argName = sac.getArgumentVariableLength(20);
-        ScriptData argIssuerAccount = sac.getArgument(20);
-        ScriptData argTokenSign = sac.getArgument(72);
+    public static String getXRPRLUSDTrustSetScript() {
+        ScriptRlpArray array = new ScriptRlpArray();
+        ScriptRlpData argFlags = array.getRlpItemArgument(); // 4 bytes or null
+        ScriptRlpData argSequence = array.getRlpItemArgument(); // 4 bytes
+        ScriptRlpData argDestinationTag = array.getRlpItemArgument(); // 4 bytes or null
+        ScriptRlpData argLastLedgerSequence = array.getRlpItemArgument(); // 4 bytes
+        ScriptRlpData argLimitAmount = array.getRlpItemArgument(); // 8 bytes
+        ScriptRlpData argFee = array.getRlpItemArgument(); // 7 bytes
+        ScriptRlpData argPublicKey = array.getRlpItemArgument(); // 33 bytes
+        ScriptRlpData argAccount = array.getRlpItemArgument(); // 20 bytes
 
         String script = new ScriptAssembler().setCoinType(0x90)
             .copyString("53545800")
-            .copyString("120014")
-            .copyString("24")
+            .copyString("12") // TransactionType
+            .copyString("0014")
+            .isEmpty(argFlags, "", new ScriptAssembler().copyString("22").copyArgument(argFlags).getScript()) // Flags
+            .copyString("24") // Sequence
             .copyArgument(argSequence)
-            .copyString("201B")
+            .isEmpty(argDestinationTag, "", // DestinationTag
+                new ScriptAssembler().copyString("2E").copyArgument(argDestinationTag).getScript())
+            .copyString("201B") // LastLedgerSequence, although optional, is strongly recommended
             .copyArgument(argLastLedgerSequence)
-            .ifSigned(argTokenInfo, argTokenSign, "", ScriptAssembler.throwSEError)
-            .copyString("63")// [value][currency][issuer AccountID]
+            .copyString("63")
             .copyArgument(argLimitAmount)
-            .setBufferIntFromDataLength(argIssuerAccount)
-            .copyArgument(argName)
-            .copyArgument(argIssuerAccount)
-            .copyString("6840")
+            .copyString("524C555344000000000000000000000000000000")
+            .copyString("E5E961C6A025C9404AA7B662DD1DF975BE75D13E")
+            .copyString("6840") // Fee
             .copyArgument(argFee)
-            .copyString("7321")
+            .copyString("7321") // SigningPubKey
             .copyArgument(argPublicKey)
-            .copyString("8114")
+            .copyString("8114") // Account
             .copyArgument(argAccount)
             .showMessage("XRP")
             .showMessage("TRUST")
-            .setBufferInt(argNameLength, 1, 7)
-            .copyArgument(argName, Buffer.CACHE1)
-            .showMessage(ScriptData.getDataBufferAll(Buffer.CACHE1))
-            .clearBuffer(Buffer.CACHE1)
+            .showMessage("RLUSD")
+            .copyString("724D78434B62454477717237365175686553554D64454766344239784A386D354465", Buffer.CACHE1)
+            .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE1))
+            .showPressButton()
+            .setHeader(HashType.SHA512, SignType.ECDSA)
+            .getScript();
+        return script;
+    }
+
+    public static String XRPRLUSDTrustSetScriptSignature = Strings.padStart(
+        "304502200751b793863ee64da47c7352cabda8a7be3ae63d10e75cb543d16c40bce60480022100d631f5d53d233516b86dae5c4a523973894ca28655af391e1b3d03f0279b31df",
+        144, '0');
+
+    public static String getXRPTrustSetScript() {
+        ScriptRlpArray array = new ScriptRlpArray();
+        ScriptRlpData argFlags = array.getRlpItemArgument(); // 4 bytes or null
+        ScriptRlpData argSequence = array.getRlpItemArgument(); // 4 bytes
+        ScriptRlpData argDestinationTag = array.getRlpItemArgument(); // 4 bytes or null
+        ScriptRlpData argLastLedgerSequence = array.getRlpItemArgument(); // 4 bytes
+        ScriptRlpData argLimitAmount = array.getRlpItemArgument(); // 8 bytes
+        ScriptRlpData argFee = array.getRlpItemArgument(); // 7 bytes
+        ScriptRlpData argPublicKey = array.getRlpItemArgument(); // 33 bytes
+        ScriptRlpData argAccount = array.getRlpItemArgument(); // 20 bytes
+        // IOU Info
+        ScriptRlpData argTokenInfo = array.getRlpItemArgument(); // 48 bytes[nameLength(1B)][name(padding zero)(7B)][tokenCode(20B)][issuerAccount(20B)]
+
+        String script = new ScriptAssembler().setCoinType(0x90)
+            .copyString("53545800")
+            .copyString("12") // TransactionType
+            .copyString("0014")
+            .isEmpty(argFlags, "", new ScriptAssembler().copyString("22").copyArgument(argFlags).getScript()) // Flags
+            .copyString("24") // Sequence
+            .copyArgument(argSequence)
+            .isEmpty(argDestinationTag, "", // DestinationTag
+                new ScriptAssembler().copyString("2E").copyArgument(argDestinationTag).getScript())
+            .copyString("201B") // LastLedgerSequence, although optional, is strongly recommended
+            .copyArgument(argLastLedgerSequence)
+            .copyArgument(argTokenInfo, Buffer.CACHE1)
+            .copyString("63")
+            .copyArgument(argLimitAmount)
+            .copyArgument(ScriptData.getBuffer(Buffer.CACHE1, 8, 40))
+            .copyString("6840") // Fee
+            .copyArgument(argFee)
+            .copyString("7321") // SigningPubKey
+            .copyArgument(argPublicKey)
+            .copyString("8114") // Account
+            .copyArgument(argAccount)
+            .showMessage("XRP")
+            .showMessage("TRUST")
+            .copyString(HexUtil.toHexString("@"), Buffer.CACHE1)
+            .setBufferInt(ScriptData.getBuffer(Buffer.CACHE1, 0, 1), 1, 7)
+            .copyArgument(ScriptData.getBuffer(Buffer.CACHE1, 1, ScriptData.bufInt), Buffer.CACHE1)
+            .showMessage(ScriptData.getDataBufferAll(Buffer.CACHE1, 48))
             .copyString("00", Buffer.CACHE2)
-            .copyArgument(argIssuerAccount, Buffer.CACHE2)
+            .copyArgument(ScriptData.getBuffer(Buffer.CACHE1, 28, 20), Buffer.CACHE2)
             .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
+            .clearBuffer(Buffer.CACHE1)
             .copyString(HexUtil.toHexString("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
                 Buffer.CACHE1)
+
             .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE2, 45, ScriptAssembler.cache1Charset,
                 ScriptAssembler.zeroInherit)
             .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53))
@@ -223,6 +272,62 @@ public class XrpScript {
     }
 
     public static String XRPTrustSetScriptSignature = Strings.padStart(
-        "3045022100b1986907b0895be91ae1b9d3318f6bd62b130d55dc12d6298fd15fda7271426502202666797aa929d8c519abb9a8c34697c79fb0f344c1f962fce5a12a7a527ffe35",
+        "3046022100a13acf6e4e0be56b54a11ff62988c51cec49b8fa2fcf27fd81ab705f0f26855c022100e5f04deaaa0e431447f4defe11b15f24df7a95266efb55956029b07491d2da71",
         144, '0');
+
+    // public static String getXRPTrustSetScript() {
+    //     ScriptArgumentComposer sac = new ScriptArgumentComposer();
+    //     ScriptData argSequence = sac.getArgument(4);
+    //     ScriptData argLastLedgerSequence = sac.getArgument(4);
+    //     ScriptData argLimitAmount = sac.getArgument(8);
+    //     ScriptData argPadding = sac.getArgument(1);
+    //     ScriptData argFee = sac.getArgument(7);
+    //     ScriptData argPublicKey = sac.getArgument(33);
+    //     ScriptData argAccount = sac.getArgument(20);
+    //     // IOU Info
+    //     ScriptData argTokenInfo = sac.getArgumentUnion(0, 41);
+    //     ScriptData argNameLength = sac.getArgument(1);
+    //     ScriptData argName = sac.getArgumentVariableLength(20);
+    //     ScriptData argIssuerAccount = sac.getArgument(20);
+    //     ScriptData argTokenSign = sac.getArgument(72);
+
+    //     String script = new ScriptAssembler().setCoinType(0x90)
+    //         .copyString("53545800")
+    //         .copyString("120014")
+    //         .copyString("24")
+    //         .copyArgument(argSequence)
+    //         .copyString("201B")
+    //         .copyArgument(argLastLedgerSequence)
+    //         .ifSigned(argTokenInfo, argTokenSign, "", ScriptAssembler.throwSEError)
+    //         .copyString("63")// [value][currency][issuer AccountID]
+    //         .copyArgument(argLimitAmount)
+    //         .setBufferIntFromDataLength(argIssuerAccount)
+    //         .copyArgument(argName)
+    //         .copyArgument(argIssuerAccount)
+    //         .copyString("6840")
+    //         .copyArgument(argFee)
+    //         .copyString("7321")
+    //         .copyArgument(argPublicKey)
+    //         .copyString("8114")
+    //         .copyArgument(argAccount)
+    //         .showMessage("XRP")
+    //         .showMessage("TRUST")
+    //         .setBufferInt(argNameLength, 1, 7)
+    //         .copyArgument(argName, Buffer.CACHE1)
+    //         .showMessage(ScriptData.getDataBufferAll(Buffer.CACHE1))
+    //         .clearBuffer(Buffer.CACHE1)
+    //         .copyString("00", Buffer.CACHE2)
+    //         .copyArgument(argIssuerAccount, Buffer.CACHE2)
+    //         .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
+    //         .copyString(HexUtil.toHexString("rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz"),
+    //             Buffer.CACHE1)
+    //         .baseConvert(ScriptData.getBuffer(Buffer.CACHE2, 0, 25), Buffer.CACHE2, 45, ScriptAssembler.cache1Charset,
+    //             ScriptAssembler.zeroInherit)
+    //         .showAddress(ScriptData.getDataBufferAll(Buffer.CACHE2, 53))
+    //         .showPressButton()
+    //         .setHeader(HashType.SHA512, SignType.ECDSA)
+    //         .getScript();
+    //     return script;
+    // }
+
 }

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/scriptlib/XrpScript.java
@@ -293,8 +293,6 @@ public class XrpScript {
         ScriptRlpData argMemoType = argMemos.getRlpItemArgument(); // variable byte or null
         ScriptRlpData argMemoData = argMemos.getRlpItemArgument(); // variable bytes or null
         ScriptRlpData argMemoFormat = argMemos.getRlpItemArgument(); // variable byte or null
-        // IOU Info
-        ScriptRlpData argTokenInfo = array.getRlpItemArgument(); // 48 bytes[nameLength(1B)][name(padding zero)(7B)][tokenCode(20B)][issuerAccount(20B)]
 
         String script = new ScriptAssembler().setCoinType(0x90)
             .copyString("53545800")
@@ -315,8 +313,8 @@ public class XrpScript {
             .copyArgument(argAmount, Buffer.CACHE2)
             .bitToByte(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE1)
             .clearBuffer(Buffer.CACHE2)
-            .copyArgument(argTokenInfo, Buffer.CACHE2)
-            .copyArgument(ScriptData.getBuffer(Buffer.CACHE2, 8, 40), Buffer.CACHE1)
+            .copyString("524C555344000000000000000000000000000000", Buffer.CACHE1)
+            .copyString("E5E961C6A025C9404AA7B662DD1DF975BE75D13E", Buffer.CACHE1)
             .copyArgument(ScriptData.getDataBufferAll(Buffer.CACHE1))
             .copyString("6840") // Fee
             .copyArgument(argFee)
@@ -339,7 +337,6 @@ public class XrpScript {
                 .getScript())
             .showMessage("XRP")
             .showMessage("RLUSD")
-            .clearBuffer(Buffer.CACHE2)
             .copyString("00", Buffer.CACHE2)
             .copyArgument(argDest, Buffer.CACHE2)
             .hash(ScriptData.getDataBufferAll(Buffer.CACHE2), Buffer.CACHE2, HashType.DoubleSHA256)
@@ -363,7 +360,7 @@ public class XrpScript {
     }
 
     public static String XRPIOURLUSDScriptSignature = Strings.padStart(
-        "304502206313724dbc74d985c680c1da43a089528be296a11f52783befd047b228e71108022100cf162503867a0a2f9ec0e58714af1db614c426cff24e6f45854c5a7ce8cec0de",
+        "3045022100a27f3abf1a1563f61349ae2d5127fb625167ca63e7e5b99413f234a99b5b9bf002206e24954c586017b5d941b38e64f0d49ec73b71e23f87dd30bc05c5f658cd0528",
         144, '0');
 
     public static String getXRPIOUScript() {

--- a/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
+++ b/script-generator/src/main/java/com/coolbitx/wallet/signing/utils/ScriptAssembler.java
@@ -889,18 +889,18 @@ public class ScriptAssembler {
      * execute the falseStatement.
      *
      * @param argData Requirement.
-     * @param signData The encoded ECDSA(CBKey) signature. Signing:
+     * @param argSign The encoded ECDSA(CBKey) signature. Signing:
      * SHA256(argData).
      * @param trueStatement The script wanna execute when the status is true.
      * @param falseStatement The script wanna execute when the status is false.
      * @return
      */
-    public ScriptAssembler ifSigned(ScriptObjectAbstract argData, ScriptData signData, String trueStatement,
+    public ScriptAssembler ifSigned(ScriptObjectAbstract argData, ScriptData argSign, String trueStatement,
         String falseStatement) {
         if (!falseStatement.equals("")) {
             trueStatement += skip(falseStatement);
         }
-        script += compose("11", argData, null, trueStatement.length() / 2, signData.getBufferParameter1())
+        script += compose("11", argData, null, trueStatement.length() / 2, argSign.getBufferParameter1())
             + trueStatement + falseStatement;
         return this;
     }


### PR DESCRIPTION
## Summary

- feat(XRP): CW-27899 support RLUSD trust set script
- feat(XRP): CW-27899 add RLUSD trust set script and refactor IOU trust set
- feat(XRP): CW-27899 add IOU payment scripts for RLUSD and generic IOU
- refactor(XRP): CW-27899 hardcode RLUSD token info in IOU payment script
- fix(XRP): CW-27899 remove SendMax field from IOU payment scripts

## Test Plan

- [ ] 驗證 RLUSD trust set script 產生正確
- [ ] 驗證 RLUSD IOU payment script 產生正確
- [ ] 驗證 generic IOU payment script 產生正確
- [ ] 本機跑過一次實際流程

## Related

- Task: https://app.clickup.com/t/CW-27899
 
 **PR Summary by Typo**
------------

#### Overview
This PR introduces support for the RLUSD (Real USD) stablecoin on the XRP ledger by adding new script generation functionalities for trust line establishment and transactions. It also includes generic IOU support for XRP.

#### Key Changes
- Added new methods `getXRPRLUSDTrustSetScript` and `getXRPIOURLUSDScript` to handle RLUSD trust set and transaction script generation.
- Implemented generic XRP IOU trust set and transaction script generation with `getXRPTrustSetScript` and `getXRPIOUScript`.
- Updated the `listAll` method in `XrpScript.java` to include the newly added XRP IOU and RLUSD scripts for listing.
- Renamed the `signData` parameter to `argSign` in the `ifSigned` method within `ScriptAssembler.java` for improved clarity.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 285 (97.9%)   |
| Refactor    | 6 (2.1%)      |
| Total Changes | 291         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>